### PR TITLE
fix(#519): fix keyboard navigation

### DIFF
--- a/src/Hypergrid.js
+++ b/src/Hypergrid.js
@@ -1193,7 +1193,7 @@ var Hypergrid = Base.extend('Hypergrid', {
      */
     insureModelRowIsVisible: function(rowIndex, offsetY) {
         var maxRows = this.getRowCount() - 1, // -1 excludes partially visible rows
-            scrollOffset = (offsetY > -1) ? 2 : -1, // 2 and -1 means there's always 1 visible row above/below the active one
+            scrollOffset = (offsetY > -1) ? 2 : 0, // 2 to keep one blank line below active cell, 0 to keep zero lines above active cell
             indexToCheck = rowIndex + scrollOffset,
             visible = !this.isDataRowVisible(indexToCheck) || rowIndex === maxRows;
 

--- a/src/Hypergrid.js
+++ b/src/Hypergrid.js
@@ -1151,7 +1151,7 @@ var Hypergrid = Base.extend('Hypergrid', {
      * @returns {boolean} The given row is fully visible.
      */
     isDataRowVisible: function(r) {
-        return this.renderer.getVisibleDataRow(r);
+        return this.renderer.isDataRowVisible(r);
     },
 
     /**
@@ -1259,7 +1259,7 @@ var Hypergrid = Base.extend('Hypergrid', {
             // target is to right of scrollable columns; positive delta scrolls right
             // Note: The +1 forces right-most column to scroll left (just in case it was only partially in view)
             } else if ((c - dw.corner.x + 1) > 0) {
-                this.sbHScroller.index = this.getMinimumLeftPositionToShowColumn(c);
+                this.sbHScroller.index = this.renderer.getMinimumLeftPositionToShowColumn(c);
             }
         }
 
@@ -1275,66 +1275,6 @@ var Hypergrid = Base.extend('Hypergrid', {
         ) {
             this.sbVScroller.index += delta;
         }
-    },
-
-    /**
-     * @desc Calculate the minimum left column index so the target column shows up in viewport (we need to be aware of viewport's width, number of fixed columns and each column's width)
-     * @param {number} targetColIdx - Target column index
-     * @returns {number} Minimum left column index so target column shows up
-     */
-    getMinimumLeftPositionToShowColumn: function(targetColIdx) {
-        var fixedColumnCount = this.getFixedColumnCount();
-        var fixedColumnsWidth = 0;
-        var rowNumbersWidth = 0;
-        var filtersWidth = 0;
-        var viewportWidth = 0;
-        var leftColIdx = 0;
-        var targetRight = 0;
-        var lastFixedColumn = null;
-        var computedCols = [];
-        var col = null;
-        var i = 0;
-        var left = 0;
-        var right = 0;
-
-
-        // 1) for each column, we'll compute left and right position in pixels (until target column)
-        for (i = 0; i <= targetColIdx; i++) {
-            left = right;
-            right += Math.ceil(this.behavior.getColumnWidth(i));
-
-            computedCols.push({
-                left: left,
-                right: right
-            });
-        }
-
-        targetRight = computedCols[computedCols.length - 1].right;
-
-        // 2) calc usable viewport width
-        lastFixedColumn = computedCols[fixedColumnCount - 1];
-
-        if (this.properties.showRowNumbers) {
-            rowNumbersWidth = this.behavior.getColumnWidth(this.behavior.rowColumnIndex);
-        }
-
-        if (this.behavior.hasTreeColumn()) {
-            filtersWidth = this.behavior.getColumnWidth(this.behavior.treeColumnIndex);
-        }
-
-        fixedColumnsWidth = lastFixedColumn ? lastFixedColumn.right : 0;
-        viewportWidth = this.getBounds().width - fixedColumnsWidth - rowNumbersWidth - filtersWidth;
-
-        // 3) from right to left, find the last column that can still render target column
-        i = targetColIdx;
-
-        do {
-            leftColIdx = i;
-            col = computedCols[i];
-            i--;
-        } while (col.left + viewportWidth > targetRight && i >= 0);
-
-        return leftColIdx;
     },
 
     selectCellAndScrollToMakeVisible: function(c, r) {

--- a/src/Hypergrid.js
+++ b/src/Hypergrid.js
@@ -1257,7 +1257,7 @@ var Hypergrid = Base.extend('Hypergrid', {
 
                 // target is to right of scrollable columns; positive delta scrolls right
                 // Note: The +1 forces right-most column to scroll left (just in case it was only partially in view)
-                (delta = c - dw.origin.x + 1) > 0
+                (delta = c - dw.corner.x + 1) > 0
             )
         ) {
             this.sbHScroller.index += delta;

--- a/src/Hypergrid.js
+++ b/src/Hypergrid.js
@@ -1151,7 +1151,7 @@ var Hypergrid = Base.extend('Hypergrid', {
      * @returns {boolean} The given row is fully visible.
      */
     isDataRowVisible: function(r) {
-        return this.renderer.isRowVisible(r);
+        return this.renderer.getVisibleDataRow(r);
     },
 
     /**
@@ -1193,7 +1193,8 @@ var Hypergrid = Base.extend('Hypergrid', {
      */
     insureModelRowIsVisible: function(rowIndex, offsetY) {
         var maxRows = this.getRowCount() - 1, // -1 excludes partially visible rows
-            indexToCheck = rowIndex + Math.sign(offsetY),
+            scrollOffset = (offsetY > -1) ? 2 : -1, // 2 and -1 means there's always 1 visible row above/below the active one
+            indexToCheck = rowIndex + scrollOffset,
             visible = !this.isDataRowVisible(indexToCheck) || rowIndex === maxRows;
 
         if (visible) {

--- a/src/Hypergrid.js
+++ b/src/Hypergrid.js
@@ -1250,18 +1250,18 @@ var Hypergrid = Base.extend('Hypergrid', {
             fixedColumnCount = this.properties.fixedColumnCount,
             fixedRowCount = this.properties.fixedRowCount;
 
-        if (
-            c >= fixedColumnCount && // scroll only if target not in fixed columns
-            (
-                // target is to left of scrollable columns; negative delta scrolls left
-                (delta = c - dw.origin.x) < 0 ||
+        // scroll only if target not in fixed columns
+        if (c >= fixedColumnCount) {
+            // target is to left of scrollable columns; negative delta scrolls left
+            if ((delta = c - dw.origin.x) < 0) {
+                this.sbHScroller.index += delta;
+            }
 
-                // target is to right of scrollable columns; positive delta scrolls right
-                // Note: The +1 forces right-most column to scroll left (just in case it was only partially in view)
-                (delta = c - dw.corner.x + 1) > 0
-            )
-        ) {
-            this.sbHScroller.index += delta;
+            // target is to right of scrollable columns; positive delta scrolls right
+            // Note: The +1 forces right-most column to scroll left (just in case it was only partially in view)
+            if ((c - dw.corner.x + 1) > 0) {
+                this.sbHScroller.index = this.getMinimumLeftPositionForColumn(c);
+            }
         }
 
         if (
@@ -1276,6 +1276,81 @@ var Hypergrid = Base.extend('Hypergrid', {
         ) {
             this.sbVScroller.index += delta;
         }
+    },
+
+    /**
+     * @desc Calculate the minimum left column index so the target column shows up in viewport (we need to be aware of viewport's width, number of fixed columns and each column's width)
+     * @param  {Number} targetColIdx  Target column index
+     * @return {Number}         Left column index so target column shows up
+     */
+    getMinimumLeftPositionForColumn: function(targetColIdx) {
+        console.log('TARGET:', targetColIdx);
+
+        // targetColIdx++;
+
+        var bounds = this.getBounds();
+        var fixedColumnCount = this.getFixedColumnCount();
+        var i = 0;
+        var col = null;
+        var left = 0;
+        var right = 0;
+        var computedCols = [];
+        var fixedWidth = 0;
+        var rowNumbersWidth = 0;
+        var filtersWidth = 0;
+        var viewWidth = 0;
+        var foundIdx = 0;
+        var targetRight = 0;
+        var lastFixedColumn = null;
+
+
+        // 1) for each column, we'll compute left and right position in pixels (until target column)
+        for (i = 0; i <= targetColIdx; i++) {
+            left = right;
+            right += Math.ceil(this.behavior.getColumnWidth(col));
+
+            computedCols.push({
+                left: left,
+                right: right
+            });
+        }
+
+        targetRight = computedCols[computedCols.length - 1].right;
+
+        // 2) calc usable viewport width
+        lastFixedColumn = computedCols[fixedColumnCount - 1];
+
+        if (this.properties.showRowNumbers) {
+            rowNumbersWidth = this.behavior.getColumnWidth(this.behavior.rowColumnIndex);
+        }
+
+        if (this.behavior.hasTreeColumn()) {
+            filtersWidth = this.behavior.getColumnWidth(this.behavior.treeColumnIndex);
+        }
+
+        fixedWidth = lastFixedColumn ? lastFixedColumn.right : 0;
+        viewWidth = bounds.width - fixedWidth - rowNumbersWidth - filtersWidth;
+
+
+        console.log('computedCols:', computedCols.map(function(a, i) { return i + ':' + a.left + '->' + a.right; }));
+        console.log('targetRight:', targetRight);
+        console.log('widths:', bounds.width, fixedWidth, rowNumbersWidth, '=>', viewWidth);
+
+        // 3) from right to left, find the last column that can still render target column
+        i = targetColIdx;
+        foundIdx = i;
+        col = computedCols[i];
+
+        while (col.left + viewWidth > targetRight && i >= 0) {
+            console.log('test ->', foundIdx, col.left + viewWidth, targetRight, col.left + viewWidth > targetRight);
+            foundIdx = i;
+            i--;
+            col = computedCols[i];
+        }
+
+        console.log('min idx:', foundIdx);
+
+        return foundIdx;
     },
 
     selectCellAndScrollToMakeVisible: function(c, r) {

--- a/src/features/CellSelection.js
+++ b/src/features/CellSelection.js
@@ -96,19 +96,20 @@ var CellSelection = Feature.extend('CellSelection', {
      */
     handleKeyDown: function(grid, event) {
         var detail = event.detail,
-            cellEvent = grid.getGridCellFromLastSelection(),
+            cellEvent = grid.getGridCellFromLastSelection(true),
             navKey = cellEvent && (
                 cellEvent.properties.mappedNavKey(detail.char, detail.ctrl) ||
                 cellEvent.properties.navKey(detail.char, detail.ctrl)
             ),
             handler = this['handle' + navKey];
 
+
         // STEP 1: Move the selection
         if (handler) {
             handler.call(this, grid, detail);
 
             // STEP 2: Open the cell editor at the new position if it has `editOnNextCell` and is `editable`
-            cellEvent = grid.getGridCellFromLastSelection(); // new cell
+            cellEvent = grid.getGridCellFromLastSelection(true); // new cell
             if (cellEvent.properties.editOnNextCell) {
                 grid.editAt(cellEvent); // succeeds only if `editable`
             }

--- a/src/lib/selection.js
+++ b/src/lib/selection.js
@@ -648,8 +648,6 @@ module.exports = {
      * @memberOf Hypergrid#
      */
     extendSelect: function(offsetX, offsetY) {
-        console.log('extendSelect...', offsetX, offsetY);
-
         var maxColumns = this.getColumnCount() - 1,
             maxRows = this.getRowCount() - 1,
 

--- a/src/lib/selection.js
+++ b/src/lib/selection.js
@@ -648,6 +648,8 @@ module.exports = {
      * @memberOf Hypergrid#
      */
     extendSelect: function(offsetX, offsetY) {
+        console.log('extendSelect...', offsetX, offsetY);
+
         var maxColumns = this.getColumnCount() - 1,
             maxRows = this.getRowCount() - 1,
 
@@ -669,8 +671,8 @@ module.exports = {
         newY = Math.min(maxRows - origin.y, Math.max(-origin.y, newY));
 
         this.clearMostRecentSelection();
-        this.select(origin.x, origin.y, newX, newY);
 
+        this.select(origin.x, origin.y, newX, newY);
         this.setDragExtent(this.newPoint(newX, newY));
 
         var colScrolled = this.insureModelColIsVisible(newX + origin.x, offsetX),

--- a/src/lib/selection.js
+++ b/src/lib/selection.js
@@ -683,15 +683,16 @@ module.exports = {
 
     /**
      * @returns {undefined|CellEvent}
+     * @param {boolean} [useAllCells] - Search in all rows and columns instead of only rendered ones.
      * @memberOf Hypergrid#
      */
-    getGridCellFromLastSelection: function() {
+    getGridCellFromLastSelection: function(useAllCells) {
         var cellEvent,
             sel = this.selectionModel.getLastSelection();
 
         if (sel) {
             cellEvent = new this.behavior.CellEvent;
-            cellEvent.resetGridXDataY(sel.origin.x, sel.origin.y);
+            cellEvent.resetGridXDataY(sel.origin.x, sel.origin.y, null, useAllCells);
         }
 
         return cellEvent;


### PR DESCRIPTION
This PR should fix multiple issues regarding the keyboard navigation.

1) Basic keyboard navigation wasn't working. 
2) Expanding selection with keyboard was broken when selection got bigger than viewport (either vertically or horizontally).
- Bug example with horizontal scrolling:
![fixed_bug4_1](https://cloud.githubusercontent.com/assets/4893840/26407678/b37fa844-4093-11e7-8fe9-07184836a74a.gif)
- Bug example with vertical scrolling:
![fixed_bug4_2](https://cloud.githubusercontent.com/assets/4893840/26407684/b71b3b94-4093-11e7-8211-8a10471e29f3.gif)

3) Expanding selection vertically with keyboard was bugged when reaching the top of the grid
![fixed_bug1](https://cloud.githubusercontent.com/assets/4893840/26407834/176b720c-4094-11e7-9e5c-d89b978e2472.gif)
