### PR TITLE
Add custom mouse wheel scrolling speed.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "chai": "^3.5.0",
     "extend-me": "^2.3",
     "fin-hypergrid-data-source-base": "^0.4.10",
-    "finbars": "1.5.2",
+    "finbars": "github:dashdash/finbars#FEATURE/custom_scroll_speed",
     "inject-stylesheet-template": "^1.0.1",
     "mustache": "2.2.0",
     "object-iterators": "1.3.0",

--- a/src/Hypergrid.js
+++ b/src/Hypergrid.js
@@ -576,11 +576,28 @@ var Hypergrid = Base.extend('Hypergrid', {
      * @param {object} properties - An object of various key value pairs.
      */
     refreshProperties: function() {
+        this.updateMouseWheelScrollSpeed();
         this.synchronizeScrollingBoundaries();
         this.computeCellsBounds();
         this.checkScrollbarVisibility();
         this.behavior.defaultRowHeight = null;
         this.behavior.autosizeAllColumns();
+    },
+
+    /**
+     * @memberOf Hypergrid#
+     * @desc Update the scrolling speed of mousewheel in finbars
+     */
+    updateMouseWheelScrollSpeed: function() {
+        var props = this.properties;
+
+        if (this.sbHScroller) {
+            this.sbHScroller.setMouseWheelScrollMultiplier(props.scrollingHorizontalMouseWheelMultiplier);
+        }
+
+        if (this.sbVScroller) {
+            this.sbVScroller.setMouseWheelScrollMultiplier(props.scrollingVerticalMouseWheelMultiplier);
+        }
     },
 
     /**
@@ -1445,7 +1462,7 @@ var Hypergrid = Base.extend('Hypergrid', {
             orientation: 'horizontal',
             onchange: self.setHScrollValue.bind(self),
             cssStylesheetReferenceElement: this.div,
-            mouseWheelSpeedMultipler: this.properties.mouseWheelSpeedMultipler
+            mouseWheelScrollMultiplier: this.properties.scrollingHorizontalMouseWheelMultiplier
         });
 
         var vertBar = new FinBar({
@@ -1455,7 +1472,7 @@ var Hypergrid = Base.extend('Hypergrid', {
                 up: self.pageUp.bind(self),
                 down: self.pageDown.bind(self)
             },
-            mouseWheelSpeedMultipler: this.properties.mouseWheelSpeedMultipler
+            mouseWheelScrollMultiplier: this.properties.scrollingVerticalMouseWheelMultiplier
         });
 
         this.sbHScroller = horzBar;

--- a/src/Hypergrid.js
+++ b/src/Hypergrid.js
@@ -1444,7 +1444,8 @@ var Hypergrid = Base.extend('Hypergrid', {
         var horzBar = new FinBar({
             orientation: 'horizontal',
             onchange: self.setHScrollValue.bind(self),
-            cssStylesheetReferenceElement: this.div
+            cssStylesheetReferenceElement: this.div,
+            mouseWheelSpeedMultipler: this.properties.mouseWheelSpeedMultipler
         });
 
         var vertBar = new FinBar({
@@ -1453,7 +1454,8 @@ var Hypergrid = Base.extend('Hypergrid', {
             paging: {
                 up: self.pageUp.bind(self),
                 down: self.pageDown.bind(self)
-            }
+            },
+            mouseWheelSpeedMultipler: this.properties.mouseWheelSpeedMultipler
         });
 
         this.sbHScroller = horzBar;

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -359,7 +359,7 @@ var defaults = {
      * @type {number}
      * @memberOf module:defaults
      */
-    scrollingHorizontalMouseWheelMultiplier: 10,
+    scrollingHorizontalMouseWheelMultiplier: 1,
 
     /**
      * @name scrollingVerticalMouseWheelMultiplier
@@ -369,7 +369,7 @@ var defaults = {
      * @type {number}
      * @memberOf module:defaults
      */
-    scrollingVerticalMouseWheelMultiplier: 10,
+    scrollingVerticalMouseWheelMultiplier: 1,
 
     /**
      * @default

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -352,6 +352,16 @@ var defaults = {
     scrollingEnabled: true,
 
     /**
+     * @name mouseWheelSpeedMultipler
+     * @summary Multiplier applied to original scroll offset returned in mousewheel scrolling event.
+     * @desc The scroll speed produced by mousewheel events may be customized passing a custom multipler. The scrolling speed will increase for multipliers above 1, decrease for a multiplier between 0 and 1, and 0 will disable mousewheel scrolling. A modulo will be applied for negative values. Defaults to 1.
+     *
+     * @type {number}
+     * @memberOf module:defaults
+     */
+    mouseWheelSpeedMultipler: 1,
+
+    /**
      * @default
      * @type {string}
      * @memberOf module:defaults

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -352,14 +352,24 @@ var defaults = {
     scrollingEnabled: true,
 
     /**
-     * @name mouseWheelSpeedMultipler
-     * @summary Multiplier applied to original scroll offset returned in mousewheel scrolling event.
+     * @name scrollingHorizontalMouseWheelMultiplier
+     * @summary Multiplier applied to original horizontal scroll offset returned in mousewheel scrolling event.
      * @desc The scroll speed produced by mousewheel events may be customized passing a custom multipler. The scrolling speed will increase for multipliers above 1, decrease for a multiplier between 0 and 1, and 0 will disable mousewheel scrolling. A modulo will be applied for negative values. Defaults to 1.
      *
      * @type {number}
      * @memberOf module:defaults
      */
-    mouseWheelSpeedMultipler: 1,
+    scrollingHorizontalMouseWheelMultiplier: 10,
+
+    /**
+     * @name scrollingVerticalMouseWheelMultiplier
+     * @summary Multiplier applied to original vertical scroll offset returned in mousewheel scrolling event.
+     * @desc The scroll speed produced by mousewheel events may be customized passing a custom multipler. The scrolling speed will increase for multipliers above 1, decrease for a multiplier between 0 and 1, and 0 will disable mousewheel scrolling. A modulo will be applied for negative values. Defaults to 1.
+     *
+     * @type {number}
+     * @memberOf module:defaults
+     */
+    scrollingVerticalMouseWheelMultiplier: 10,
 
     /**
      * @default


### PR DESCRIPTION
Two new properties were added `scrollingHorizontalMouseWheelMultiplier` and `scrollingVerticalMouseWheelMultiplier`, which are proxied to `finbars`.

These values can be set as:
- between 0 and 1 -> decrease speed;
- 1 -> original speed (default value);
- above 1 -> increase speed;
- negative values will invert the scrolling (could probably apply a modulo on this?...)

This should implement issue #290.
Thanks!