### PR TITLE
fix(#621) - fix first typed character when opening the cell editor for non-US keyboards

### DIFF
--- a/src/lib/Canvas.js
+++ b/src/lib/Canvas.js
@@ -417,8 +417,16 @@ Canvas.prototype = {
 
     getKeyChar: function(e) {
         var key = e.keyCode || e.detail.key,
-            shift = e.shiftKey || e.detail.shift;
-        return charMap[key][shift ? 1 : 0];
+            shift = e.shiftKey || e.detail.shift,
+            mappedKey = charMap[key][shift ? 1 : 0];
+
+        // don't map simple keys (e.g. letters, digits and symbols)
+        // to improve support for non-US keyboards
+        if (typeof mappedKey === 'string' && mappedKey.length === 1) {
+            mappedKey = e.key;
+        }
+
+        return mappedKey;
     },
 
     finkeydown: function(e) {

--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -112,7 +112,7 @@ module.exports = {
         return dispatchEvent.call(this, 'fin-editor-keyup', {
             input: inputControl,
             keyEvent: keyEvent,
-            char: this.canvas.getCharMap()[keyEvent.keyCode][keyEvent.shiftKey ? 1 : 0]
+            char: this.canvas.getKeyChar(keyEvent)
         });
     },
 
@@ -120,7 +120,7 @@ module.exports = {
         return dispatchEvent.call(this, 'fin-editor-keydown', {
             input: inputControl,
             keyEvent: keyEvent,
-            char: this.canvas.getCharMap()[keyEvent.keyCode][keyEvent.shiftKey ? 1 : 0]
+            char: this.canvas.getKeyChar(keyEvent)
         });
     },
 
@@ -128,7 +128,7 @@ module.exports = {
         return dispatchEvent.call(this, 'fin-editor-keypress', {
             input: inputControl,
             keyEvent: keyEvent,
-            char: this.canvas.getCharMap()[keyEvent.keyCode][keyEvent.shiftKey ? 1 : 0]
+            char: this.canvas.getKeyChar(keyEvent)
         });
     },
 


### PR DESCRIPTION
**Description**
When using the keyboard to open cell editor, by start typing a visible character, some characters may not be correctly mapped in the charMap from Canvas.js when the user is using a keyboard layout different from the US (e.g. portuguese layout).

I've updated the `getKeyChar()` to prevent using the mapped key if it's a simple character (e.g. a letter, a digit or a symbol). Because there's too much logic in hypergrid that depends on the complex keys returned here, e.g. keys for arrows and some keys combined with shift, we cannot remove the charmap and just return the original `e.key`.
The charMap can be stripped down of simple keys and `getKeyChar()` refactored to fallback to `e.key` every time a mapping returns `undefined`.

If #522 goes forward, the code may be refactored to rely more on the original keyboard and mouse event data , like `e.key` values, instead of the mapped keys.

**Test conditions**
OS: Mac OS v10.12.6
Browsers: Chrome 60.0.3112.113 and Firefox 55
Keyboard layout: Portuguese and US international