### PR TITLE
fix(#623) - Fix open editor with space key (must be treated as a normal character)

### DIFF
--- a/src/Hypergrid.js
+++ b/src/Hypergrid.js
@@ -1133,7 +1133,7 @@ var Hypergrid = Base.extend('Hypergrid', {
      * @returns {boolean} The given row is fully visible.
      */
     isDataRowVisible: function(r) {
-        return this.renderer.isRowVisible(r);
+        return this.renderer.isDataRowVisible(r);
     },
 
     /**
@@ -1175,7 +1175,8 @@ var Hypergrid = Base.extend('Hypergrid', {
      */
     insureModelRowIsVisible: function(rowIndex, offsetY) {
         var maxRows = this.getRowCount() - 1, // -1 excludes partially visible rows
-            indexToCheck = rowIndex + Math.sign(offsetY),
+            scrollOffset = (offsetY > -1) ? 2 : 0, // 2 to keep one blank line below active cell, 0 to keep zero lines above active cell
+            indexToCheck = rowIndex + scrollOffset,
             visible = !this.isDataRowVisible(indexToCheck) || rowIndex === maxRows;
 
         if (visible) {
@@ -1231,18 +1232,17 @@ var Hypergrid = Base.extend('Hypergrid', {
             fixedColumnCount = this.properties.fixedColumnCount,
             fixedRowCount = this.properties.fixedRowCount;
 
-        if (
-            c >= fixedColumnCount && // scroll only if target not in fixed columns
-            (
-                // target is to left of scrollable columns; negative delta scrolls left
-                (delta = c - dw.origin.x) < 0 ||
+        // scroll only if target not in fixed columns
+        if (c >= fixedColumnCount) {
+            // target is to left of scrollable columns; negative delta scrolls left
+            if ((delta = c - dw.origin.x) < 0) {
+                this.sbHScroller.index += delta;
 
-                // target is to right of scrollable columns; positive delta scrolls right
-                // Note: The +1 forces right-most column to scroll left (just in case it was only partially in view)
-                (delta = c - dw.origin.x + 1) > 0
-            )
-        ) {
-            this.sbHScroller.index += delta;
+            // target is to right of scrollable columns; positive delta scrolls right
+            // Note: The +1 forces right-most column to scroll left (just in case it was only partially in view)
+            } else if ((c - dw.corner.x + 1) > 0) {
+                this.sbHScroller.index = this.renderer.getMinimumLeftPositionToShowColumn(c);
+            }
         }
 
         if (

--- a/src/features/CellEditing.js
+++ b/src/features/CellEditing.js
@@ -3,6 +3,15 @@
 var Feature = require('./Feature');
 var CellEditor = require('../cellEditors/CellEditor');
 
+var KEYS = {
+    RETURN: 'RETURN',
+    RETURNSHIFT: 'RETURNSHIFT',
+    DELETE: 'DELETE',
+    BACKSPACE: 'BACKSPACE',
+    SPACE: 'SPACE',
+    F2: 'F2'
+};
+
 /**
  * @constructor
  * @extends Feature
@@ -42,22 +51,23 @@ var CellEditing = Feature.extend('CellEditing', {
      * @memberOf KeyPaging.prototype
      */
     handleKeyDown: function(grid, event) {
-        var char, isVisibleChar, isDeleteChar, editor, cellEvent;
+        var char = event.detail.char,
+            cellEvent = grid.getGridCellFromLastSelection(),
+            isEditable = cellEvent && cellEvent.properties.editOnKeydown && !grid.cellEditor,
+            isVisibleChar = char.length === 1 && !(event.detail.meta || event.detail.ctrl),
+            isSpaceChar = char === KEYS.SPACE,
+            isDeleteChar = char === KEYS.DELETE || char === KEYS.BACKSPACE,
+            isEditChar = char === KEYS.F2,
+            isValidChar = isVisibleChar || isSpaceChar || isDeleteChar || isEditChar,
+            editor;
 
-        if (
-            (cellEvent = grid.getGridCellFromLastSelection()) &&
-            cellEvent.properties.editOnKeydown &&
-            !grid.cellEditor &&
-            (
-                (char = event.detail.char) === 'F2' ||
-                (isVisibleChar = char.length === 1 && !(event.detail.meta || event.detail.ctrl)) ||
-                (isDeleteChar = char === 'DELETE' || char === 'BACKSPACE')
-            )
-        ) {
+        if (isEditable && isValidChar) {
             editor = grid.onEditorActivate(cellEvent);
 
             if (editor instanceof CellEditor) {
-                if (isVisibleChar) {
+                if (isSpaceChar) {
+                    editor.input.value = ' ';
+                } else if (isVisibleChar) {
                     editor.input.value = char;
                 } else if (isDeleteChar) {
                     editor.setEditorValue('');

--- a/src/features/CellSelection.js
+++ b/src/features/CellSelection.js
@@ -96,19 +96,20 @@ var CellSelection = Feature.extend('CellSelection', {
      */
     handleKeyDown: function(grid, event) {
         var detail = event.detail,
-            cellEvent = grid.getGridCellFromLastSelection(),
+            cellEvent = grid.getGridCellFromLastSelection(true),
             navKey = cellEvent && (
                 cellEvent.properties.mappedNavKey(detail.char, detail.ctrl) ||
                 cellEvent.properties.navKey(detail.char, detail.ctrl)
             ),
             handler = this['handle' + navKey];
 
+
         // STEP 1: Move the selection
         if (handler) {
             handler.call(this, grid, detail);
 
             // STEP 2: Open the cell editor at the new position if it has `editOnNextCell` and is `editable`
-            cellEvent = grid.getGridCellFromLastSelection(); // new cell
+            cellEvent = grid.getGridCellFromLastSelection(true); // new cell
             if (cellEvent.properties.editOnNextCell) {
                 grid.editAt(cellEvent); // succeeds only if `editable`
             }

--- a/src/lib/selection.js
+++ b/src/lib/selection.js
@@ -669,8 +669,8 @@ module.exports = {
         newY = Math.min(maxRows - origin.y, Math.max(-origin.y, newY));
 
         this.clearMostRecentSelection();
-        this.select(origin.x, origin.y, newX, newY);
 
+        this.select(origin.x, origin.y, newX, newY);
         this.setDragExtent(this.newPoint(newX, newY));
 
         var colScrolled = this.insureModelColIsVisible(newX + origin.x, offsetX),
@@ -683,15 +683,16 @@ module.exports = {
 
     /**
      * @returns {undefined|CellEvent}
+     * @param {boolean} [useAllCells] - Search in all rows and columns instead of only rendered ones.
      * @memberOf Hypergrid#
      */
-    getGridCellFromLastSelection: function() {
+    getGridCellFromLastSelection: function(useAllCells) {
         var cellEvent,
             sel = this.selectionModel.getLastSelection();
 
         if (sel) {
             cellEvent = new this.behavior.CellEvent;
-            cellEvent.resetGridXDataY(sel.origin.x, sel.origin.y);
+            cellEvent.resetGridXDataY(sel.origin.x, sel.origin.y, null, useAllCells);
         }
 
         return cellEvent;


### PR DESCRIPTION
Fixes [#623](https://github.com/fin-hypergrid/core/issues/623).

**Description**
When using the keyboard to start cell editor, we cannot use the space key to open the cell editor and replace its content with a new space character.
Everything works fine if we type a "normal" character.

**Test conditions**
OS: Mac OS v10.12.6
Browsers: Chrome 60.0.3112.113 and Firefox 55

**How to reproduce**
- Open hypergrid's demo app;
- Focus on an editable cell (either with or without content);
- Hit the "space" key (nothing happens -> should have opened the editor);
- Hit the "a" key (a new editor with "a" value type should be rendered).
