### PR TITLE
fix(#623) - Fix open editor with space key (must be treated as a normal character)

### DIFF
--- a/src/features/CellEditing.js
+++ b/src/features/CellEditing.js
@@ -18,24 +18,6 @@ var KEYS = {
  */
 var CellEditing = Feature.extend('CellEditing', {
 
-    isVisibleChar: function(char, event) {
-        return !!(
-            (char.length === 1) && !(event.detail.meta || event.detail.ctrl)
-        );
-    },
-
-    isSpaceChar: function(char, event) {
-        return char === KEYS.SPACE;
-    },
-
-    isDeleteChar: function(char, event) {
-        return (char === KEYS.DELETE || char === KEYS.BACKSPACE);
-    },
-
-    isEditChar: function(char, event) {
-        return (char === KEYS.F2 || char === KEYS.RETURN || char === KEYS.RETURNSHIFT);
-    },
-
     /**
      * @memberOf CellEditing.prototype
      * @param {Hypergrid} grid
@@ -70,21 +52,23 @@ var CellEditing = Feature.extend('CellEditing', {
      */
     handleKeyDown: function(grid, event) {
         var char = event.detail.char,
-            isVisibleChar = this.isVisibleChar(char, event),
-            isSpaceChar = this.isSpaceChar(char, event),
-            isDeleteChar = this.isDeleteChar(char, event),
-            isEditChar = this.isEditChar(char, event),
-            isValidChar = !!(isVisibleChar || isSpaceChar || isDeleteChar || isEditChar),
             cellEvent = grid.getGridCellFromLastSelection(),
-            isEditable = (cellEvent && cellEvent.properties.editOnKeydown && !grid.cellEditor),
+            isEditable = cellEvent && cellEvent.properties.editOnKeydown && !grid.cellEditor,
+            isVisibleChar = char.length === 1 && !(event.detail.meta || event.detail.ctrl),
+            isSpaceChar = char === KEYS.SPACE,
+            isDeleteChar = char === KEYS.DELETE || char === KEYS.BACKSPACE,
+            isEditChar = char === KEYS.F2,
+            isValidChar = isVisibleChar || isSpaceChar || isDeleteChar || isEditChar,
             editor;
 
         if (isEditable && isValidChar) {
             editor = grid.onEditorActivate(cellEvent);
 
             if (editor instanceof CellEditor) {
-                if (isVisibleChar || isSpaceChar) {
-                    editor.input.value = isSpaceChar ? ' ' : char;
+                if (isSpaceChar) {
+                    editor.input.value = ' ';
+                } else if (isVisibleChar) {
+                    editor.input.value = char;
                 } else if (isDeleteChar) {
                     editor.setEditorValue('');
                 }


### PR DESCRIPTION
Fixes [#623](https://github.com/fin-hypergrid/core/issues/623).

**Description**
When using the keyboard to start cell editor, we cannot use the space key to open the cell editor and replace its content with a new space character.
Everything works fine if we type a "normal" character.

**Test conditions**
OS: Mac OS v10.12.6
Browsers: Chrome 60.0.3112.113 and Firefox 55

**How to reproduce**
- Open hypergrid's demo app;
- Focus on an editable cell (either with or without content);
- Hit the "space" key (nothing happens -> should have opened the editor);
- Hit the "a" key (a new editor with "a" value type should be rendered).

Note: I've created this new PR because I've messed up with the original branch history.