### PR TITLE
Remove treeColumnIndex/rowColumnIndex from DataSourceOrigin

### DIFF
--- a/src/behaviors/Behavior.js
+++ b/src/behaviors/Behavior.js
@@ -131,21 +131,25 @@ var Behavior = Base.extend('Behavior', {
         return this.grid.renderer.visibleRows.length;
     },
 
-    get treeColumnIndex() {
-        return -1;
-    },
-
-    get rowColumnIndex() {
-        return -2;
-    },
-
     get leftMostColIndex() {
         return this.grid.properties.showRowNumbers ? this.rowColumnIndex : (this.hasTreeColumn() ? this.treeColumnIndex : 0);
     },
 
     clearColumns: function() {
-        var tc = this.treeColumnIndex;
-        var rc = this.rowColumnIndex;
+        var schema = this.dataModel.schema,
+            tc = this.treeColumnIndex,
+            rc = this.rowColumnIndex;
+
+        schema[tc] = schema[tc] || {
+            name: 'Tree',
+            header: 'Tree'
+        };
+
+        schema[rc] = schema[rc] || {
+            name: '',
+            header: ''
+        };
+
         /**
          * @type {Column[]}
          * @memberOf Behavior#
@@ -160,11 +164,11 @@ var Behavior = Base.extend('Behavior', {
 
         this.allColumns[tc] = this.columns[tc] = this.newColumn({
             index: tc,
-            header: this.dataModel.schema[tc].header
+            header: schema[tc].header
         });
         this.allColumns[rc] = this.columns[rc] = this.newColumn({
             index: rc,
-            header: this.dataModel.schema[rc].header
+            header: schema[rc].header
         });
     },
 
@@ -1389,6 +1393,12 @@ var Behavior = Base.extend('Behavior', {
     getIndexedData: function() {
        this.dataModel.getIndexedData();
     }
+});
+
+// define constants as immutable (i.e., !writable)
+Object.defineProperties(Behavior.prototype, {
+    treeColumnIndex: { value: -1 },
+    rowColumnIndex: { value: -2 }
 });
 
 // synonyms

--- a/src/dataModels/JSON.js
+++ b/src/dataModels/JSON.js
@@ -61,9 +61,7 @@ var JSON = DataModel.extend('dataModels.JSON', {
         options = options || {};
         this.source = new this.DataSourceOrigin(
             options.data,
-            options.schema,
-            this.grid.behavior.treeColumnIndex,
-            this.grid.behavior.rowColumnIndex
+            options.schema
         );
 
         this.setPipeline({

--- a/src/lib/DataSourceOrigin.js
+++ b/src/lib/DataSourceOrigin.js
@@ -15,11 +15,9 @@ var DataSourceOrigin = DataSourceBase.extend('DataSourceOrigin',  {
     /**
      * Currently a synonym for {@link DataSourceOrigin#setData} (see).
      */
-    initialize: function(data, schema, ti, ri) {
+    initialize: function(data, schema) {
         delete this.dataSource; // added by DataSourceBase#initialize but we don't want here
-        this.treeColumnIndex = ti;
-        this.rowColumnIndex = ri;
-        this._schema = setInternalColSchema.call(this, []);
+        this._schema = [];
         this.setData(data, schema);
     },
 
@@ -56,7 +54,6 @@ var DataSourceOrigin = DataSourceBase.extend('DataSourceOrigin',  {
 
     get schema() { return this._schema; },
     set schema(schema) {
-        schema = setInternalColSchema.call(this, schema);
         this._schema = schema;
     },
 
@@ -82,7 +79,7 @@ var DataSourceOrigin = DataSourceBase.extend('DataSourceOrigin',  {
                 schema[i] = { name: fields[i] };
             }
         }
-        schema = setInternalColSchema.call(this, schema);
+
         /**
          * @summary The array of column schema objects.
          * @name schema
@@ -331,16 +328,6 @@ var DataSourceOrigin = DataSourceBase.extend('DataSourceOrigin',  {
         }, this);
     }
 });
-
-function setInternalColSchema(schema) {
-    if (!schema[this.treeColumnIndex]) {
-        schema[this.treeColumnIndex] = {name: 'Tree', header: 'Tree'}; //Tree Column
-    }
-    if (!schema[this.rowColumnIndex]) {
-        schema[this.rowColumnIndex] = {name: '', header: ''}; //Row Handle Column
-    }
-    return schema;
-}
 
 
 module.exports = DataSourceOrigin;

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -659,11 +659,11 @@ var Renderer = Base.extend('Renderer', {
         lastFixedColumn = computedCols[fixedColumnCount - 1];
 
         if (this.properties.showRowNumbers) {
-            rowNumbersWidth = this.grid.getColumnWidth(this.grid.rowColumnIndex);
+            rowNumbersWidth = this.grid.getColumnWidth(this.grid.behavior.rowColumnIndex);
         }
 
         if (this.grid.hasTreeColumn()) {
-            filtersWidth = this.grid.getColumnWidth(this.grid.treeColumnIndex);
+            filtersWidth = this.grid.getColumnWidth(this.grid.behavior.treeColumnIndex);
         }
 
         fixedColumnsWidth = lastFixedColumn ? lastFixedColumn.right : 0;


### PR DESCRIPTION
See issue #634 except this PR removes `treeColumnIndex` and `rowColumnIndex` from the data source entirely (without implementing an `options` object to hold them, as originally recommended in the issue).

Also addresses issue #641.