### PR TITLE
FIx issue in IE with I-beam cursor

### DIFF
--- a/src/lib/Canvas.js
+++ b/src/lib/Canvas.js
@@ -94,7 +94,7 @@ function Canvas(div, component) {
     });
 
     this.canvas.setAttribute('tabindex', 0);
-    this.canvas.contentEditable = true;
+    //this.canvas.contentEditable = true;
 
     this.resize();
 

--- a/src/lib/Canvas.js
+++ b/src/lib/Canvas.js
@@ -94,7 +94,6 @@ function Canvas(div, component) {
     });
 
     this.canvas.setAttribute('tabindex', 0);
-    //this.canvas.contentEditable = true;
 
     this.resize();
 


### PR DESCRIPTION
Not sure why content editable was ever set on a canvas element, but in IE it causes the cursor to always be the I-beam shape. This fixes the first part of #617 

