### PR TITLE
Don't do anything if there's no data

### DIFF
--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -341,6 +341,10 @@ module.exports = {
         var self = this;
 
         function handleMouseEvent(e, cb) {
+            if (self.getRowCount() === 0) {
+                return;
+            }
+
             var c = self.getGridCellFromMousePoint(e.detail.mouse),
                 primitiveEvent,
                 decoratedEvent;


### PR DESCRIPTION
If the grid has no data, this function starts throwing spurious console errors as the user mouses over the empty grid.