### PR TITLE
Make sure canvas size is integral

### DIFF
--- a/src/lib/Canvas.js
+++ b/src/lib/Canvas.js
@@ -213,7 +213,7 @@ Canvas.prototype = {
         this.stopResizing();
     },
 
-    divBoundingClientRect: function() {
+    getDivBoundingClientRect: function() {
         // Make sure our canvas has integral dimensions
         var rect = this.div.getBoundingClientRect();
         var top = Math.floor(rect.top),
@@ -235,14 +235,14 @@ Canvas.prototype = {
 
     checksize: function() {
         //this is expensive lets do it at some modulo
-        var sizeNow = this.divBoundingClientRect();
+        var sizeNow = this.getDivBoundingClientRect();
         if (sizeNow.width !== this.size.width || sizeNow.height !== this.size.height) {
             this.resize();
         }
     },
 
     resize: function() {
-        var box = this.size = this.divBoundingClientRect();
+        var box = this.size = this.getDivBoundingClientRect();
 
         this.width = box.width;
         this.height = box.height;

--- a/src/lib/Canvas.js
+++ b/src/lib/Canvas.js
@@ -215,7 +215,7 @@ Canvas.prototype = {
 
     divBoundingClientRect: function() {
         // Make sure our canvas has integral dimensions
-        var size = this.div.getBoundingClientRect();
+        var rect = this.div.getBoundingClientRect();
         var top = Math.floor(rect.top),
             left = Math.floor(rect.left),
             width = Math.ceil(rect.width),
@@ -223,8 +223,8 @@ Canvas.prototype = {
 
         return {
             top: top,
-            right: left+width,
-            bottom: top+height,
+            right: left + width,
+            bottom: top + height,
             left: left,
             width: width,
             height: height,

--- a/src/lib/Canvas.js
+++ b/src/lib/Canvas.js
@@ -213,16 +213,36 @@ Canvas.prototype = {
         this.stopResizing();
     },
 
+    divBoundingClientRect: function() {
+        // Make sure our canvas has integral dimensions
+        var size = this.div.getBoundingClientRect();
+        var top = Math.floor(rect.top),
+            left = Math.floor(rect.left),
+            width = Math.ceil(rect.width),
+            height = Math.ceil(rect.height);
+
+        return {
+            top: top,
+            right: left+width,
+            bottom: top+height,
+            left: left,
+            width: width,
+            height: height,
+            x: rect.x,
+            y: rect.y
+        };
+    },
+
     checksize: function() {
         //this is expensive lets do it at some modulo
-        var sizeNow = this.div.getBoundingClientRect();
+        var sizeNow = this.divBoundingClientRect();
         if (sizeNow.width !== this.size.width || sizeNow.height !== this.size.height) {
             this.resize();
         }
     },
 
     resize: function() {
-        var box = this.size = this.div.getBoundingClientRect();
+        var box = this.size = this.divBoundingClientRect();
 
         this.width = box.width;
         this.height = box.height;


### PR DESCRIPTION
When using hypergrid in a layout engine (like phosphor or golden-layout), sometimes these engines give the canvas a non-integral width and height, which causes text aliasing issues since canvas support subpixel referencing. This fix just floors the bounds of the canvas element in a consistent way.