### PR TITLE
Focused mouseup

### DIFF
--- a/src/lib/Canvas.js
+++ b/src/lib/Canvas.js
@@ -351,6 +351,10 @@ Canvas.prototype = {
     },
 
     finmouseup: function(e) {
+        if (!this.mousedown) {
+            // ignore document:mouseup unless preceded by a canvas:mousedown
+            return;
+        }
         if (this.isDragging()) {
             this.dispatchNewMouseKeysEvent(e, 'fin-canvas-dragend', {
                 dragstart: this.dragstart,


### PR DESCRIPTION
`mouseup` has to be on `document` to support column dragging — unlike other mouse events which are on `canvas`.

The problem was the handler for all grid instances receive `mouseup` events on a single mouse up.

This PR resolves this issue by implementing a "focused" `mouseup` handler, _i.e.,_ ignoring `mouseup` events except when preceded by the already-focused `mousedown` event. This works because only one of the grid instances could have gotten the `mousedown` (there being only one mouse pointer).
  
  