### PR TITLE
Feature chain property

### DIFF
--- a/demo/js/demo/celleditors.js
+++ b/demo/js/demo/celleditors.js
@@ -6,7 +6,7 @@ module.exports = function(demo, grid) {
 
     var idx = grid.behavior.columnEnum;
 
-    var CellEditor = grid.cellEditors.get('celleditor');
+    var CellEditor = grid.cellEditors.BaseClass;
     var Textfield = grid.cellEditors.get('textfield');
 
     var ColorText = Textfield.extend('colorText', {

--- a/demo/js/demo/cellrenderers.js
+++ b/demo/js/demo/cellrenderers.js
@@ -188,7 +188,7 @@ module.exports = function(demo, grid) {
 
 
     //Extend HyperGrid's base Renderer
-    var sparkStarRatingRenderer = grid.cellRenderers.get('emptycell').constructor.extend({
+    var sparkStarRatingRenderer = grid.cellRenderers.BaseClass.extend({
         paint: paintSparkRating
     });
 

--- a/src/Hypergrid.js
+++ b/src/Hypergrid.js
@@ -17,7 +17,8 @@ var Canvas = require('./lib/Canvas');
 var Renderer = require('./renderer');
 var SelectionModel = require('./lib/SelectionModel');
 var Localization = require('./lib/Localization');
-var behaviors = require('./behaviors');
+var Behavior = require('./behaviors/Behavior');
+var behaviorJSON = require('./behaviors/JSON');
 var CellRenderers = require('./cellRenderers');
 var CellEditors = require('./cellEditors');
 
@@ -115,7 +116,7 @@ var Hypergrid = Base.extend('Hypergrid', {
          * @type {CellEditor}
          * @memberOf Hypergrid#
          */
-        this.cellEditors = new CellEditors(this);
+        this.cellEditors = new CellEditors({ grid: this });
 
         if (this.options.Behavior) {
             this.setBehavior(this.options); // also sets this.options.pipeline and this.options.data
@@ -413,7 +414,7 @@ var Hypergrid = Base.extend('Hypergrid', {
             // set first two args of `preinstall` method to `this` (the Hypergrid prototype) and the Behavior prototype
             args = [this];
             if (shared) {
-                args.push(behaviors.Behavior.prototype);
+                args.push(Behavior.prototype);
             }
 
             if (Array.isArray(plugin)) {
@@ -793,7 +794,7 @@ var Hypergrid = Base.extend('Hypergrid', {
             // If we get here it means:
             // 1. Called from constructor because behavior included in options object.
             // 2. Called from `setData` _and_ wasn't called explicitly since instantiation
-            var Behavior = options.Behavior || behaviors.JSON;
+            var Behavior = options.Behavior || behaviorJSON;
             this.behavior = new Behavior(this, options);
             this.initCanvas();
             this.initScrollbars();

--- a/src/Hypergrid.js
+++ b/src/Hypergrid.js
@@ -29,7 +29,7 @@ var EDGE_STYLES = ['top', 'bottom', 'left', 'right'],
  * @constructor
  * @param {string|Element} [container] - CSS selector or Element
  * @param {object} [options]
- * @param {function} [options.Behavior=behaviors.JSON] - A behavior constructor or instance
+ * @param {function} [options.Behavior=behaviors.JSON] - A grid behavior constructor (extended from {@link Behavior}).
  * @param {function[]} [options.pipeline] - A list function constructors to use for passing data through a series of transforms to occur on reindex call
  * @param {function|object[]} [options.data] - Passed to behavior constructor. May be:
  * * An array of congruent raw data objects
@@ -38,7 +38,6 @@ var EDGE_STYLES = ['top', 'bottom', 'left', 'right'],
  * * A schema array
  * * A function returning a schema array. Called at filter reset time with behavior as context.
  * * Omit to generate a basic schema from `this.behavior.columns`.
- * @param {Behavior} [options.Behavior=JSON] - A grid behavior (descendant of Behavior "class").
  *
  * @param {pluginSpec|pluginSpec[]} [options.plugins]
  *

--- a/src/behaviors/JSON.js
+++ b/src/behaviors/JSON.js
@@ -3,7 +3,6 @@
 var Behavior = require('./Behavior');
 var columnEnumDecorators = require('./columnEnumDecorators');
 var DataModelJSON = require('../dataModels/JSON');
-var features = require('../features');
 
 /**
  * @name behaviors.JSON
@@ -30,21 +29,6 @@ var JSON = Behavior.extend('behaviors.JSON', {
             this.setPipeline(options.pipeline);
         }
     },
-
-    features: [
-        features.Filters,
-        features.CellSelection,
-        features.KeyPaging,
-        features.ColumnResizing,
-        // features.RowResizing,
-        features.RowSelection,
-        features.ColumnSelection,
-        features.ColumnMoving,
-        features.ColumnSorting,
-        features.CellClick,
-        features.CellEditing,
-        features.OnHover
-    ],
 
     createColumns: function() {
         Behavior.prototype.createColumns.call(this);

--- a/src/behaviors/JSON.js
+++ b/src/behaviors/JSON.js
@@ -195,7 +195,7 @@ var JSON = Behavior.extend('behaviors.JSON', {
             this.createColumns();
         }
 
-        grid.allowEvents(this.dataModel.getRowCount() > 0);
+        grid.allowEvents(this.getRowCount());
     },
 
     /**

--- a/src/behaviors/index.js
+++ b/src/behaviors/index.js
@@ -1,5 +1,8 @@
 'use strict';
 
+// This module is provided solely in support of build file usage, e.g., `fin.Hypergrid.behaviors.yada`,
+// and is not meant to be used elsewhere.
+
 module.exports = {
     Behavior: require('./Behavior'),
     JSON: require('./JSON'),

--- a/src/cellEditors/index.js
+++ b/src/cellEditors/index.js
@@ -1,110 +1,53 @@
 'use strict';
 
+var Registry = require('../lib/Registry');
+
+
+var deprecated = {
+    celleditor: undefined,
+    CellEditor: undefined
+};
+
+
 /**
- *
- * @param {Hypergrid} grid
- * @param {boolean} [privateRegistry=false] - This instance will use a private registry.
+ * @classdesc Registry of cell editor constructors.
+ * @param {Hypergrid} options.grid
+ * @param {boolean} [options.private=false] - This instance will use a private registry.
  * @constructor
  */
-function CellEditors(grid, privateRegistry) {
-    this.grid = grid;
+var CellEditors = Registry.extend('CellEditors', {
 
-    if (privateRegistry) {
-        this.editors = {};
-    }
+    BaseClass: require('./CellEditor'), // abstract base class
 
-    // preregister the standard cell editors
-    if (privateRegistry || !this.get('celleditor')) {
-        this.add(require('./CellEditor'));
-        this.add(require('./Color'));
-        this.add(require('./Date'));
-        this.add(require('./Number'));
-        this.add(require('./Slider'));
-        this.add(require('./Spinner'));
-        this.add(require('./Textfield'));
-    }
-}
+    items: {}, // shared cell editor registry (when !options.private)
 
-CellEditors.prototype = {
-    constructor: CellEditors.prototype.constructor, // preserve constructor
-
-    /**
-     * @summary Register a cell editor constructor.
-     * @desc Adds a custom cell editor constructor to the `editors` hash using the provided name (or the class name), converted to all lower case.
-     *
-     * > All native cell editors are "preregistered" in `editors`..
-     *
-     * @param {string} [name] - Case-insensitive editor key. If not given, `YourCellEditor.prototype.$$CLASS_NAME` is used.
-     *
-     * @param {YourCellEditor.prototype.constructor} Constructor - A constructor, typically extended from `CellEditor` (or a descendant therefrom).
-     *
-     * > Note: `$$CLASS_NAME` can be easily set up by providing a string as the (optional) first parameter (`alias`) in your {@link https://www.npmjs.com/package/extend-me|CellEditor.extend} call.
-     *
-     * @returns {CellEditor} A newly registered constructor extended from {@link CellEditor}.
-     *
-     * @memberOf CellEditors#
-     */
-    add: function(name, Constructor) {
-        if (typeof name === 'function') {
-            Constructor = name;
-            name = undefined;
+    initialize: function(options) {
+        // preregister the standard cell editors
+        if (options && options.private || !this.items.celleditor) {
+            this.add(require('./Color'));
+            this.add(require('./Date'));
+            this.add(require('./Number'));
+            this.add(require('./Slider'));
+            this.add(require('./Spinner'));
+            this.add(require('./Textfield'));
         }
-
-        name = name || Constructor.prototype.$$CLASS_NAME;
-        name = name && name.toLowerCase();
-        this.editors[name] = Constructor;
-        return Constructor;
     },
 
-    /**
-     * @summary Register a synonym for an existing cell editor constructor.
-     * @param {string} synonymName
-     * @param {string} existingName
-     * @returns {CellEditor} The previously registered constructor this new synonym points to.
-     * @memberOf CellEditors#
-     */
-    addSynonym: function(synonymName, existingName) {
-        var cellEditor = this.get(existingName);
-        return (this.editors[synonymName] = cellEditor);
+    construct: function(Constructor, options) {
+        return new Constructor(this.options.grid, options);
     },
 
-    /**
-     * @param {string} name - Name of a registered editor.
-     * @returns {CellEditor} A registered constructor extended from {@link CellEditor}.
-     * @memberOf CellEditors#
-     */
     get: function(name) {
-        return this.editors[name && name.toLowerCase()];
-    },
-
-    /**
-     * @summary Lookup registered cell editor and return a new instance thereof.
-     * @desc Note: Must be called with the Hypergrid object as context!
-     * @returns {CellEditor} New instance of the named cell editor.
-     * @param {string} name - Name of a registered editor.
-     * @param {string} [options] - Properties to add to the instantiated editor primarily for mustache's use.
-     * @memberOf CellEditors#
-     */
-    create: function(name, options) {
-        var cellEditor,
-            Constructor = this.get(name);
-
-        if (Constructor) {
-            if (Constructor.abstract) {
-                throw 'Attempt to instantiate an "abstract" cell editor class.';
+        if (name in deprecated) {
+            if (!deprecated.warned) {
+                console.warn('grid.cellEditors.get("' + name + '") method call has been deprecated as of v2.1.0 in favor of grid.cellEditors.BaseClass property. (Will be removed in a future release.)');
+                deprecated.warned = true;
             }
-            cellEditor = new Constructor(this.grid, options);
+            return this.BaseClass;
         }
+        return this.super.get.call(this, name);
+    }
 
-        return cellEditor;
-    },
-
-    /**
-     * The cell editor registry containing all the "preregistered" cell editor constructors.
-     * @private
-     * @memberOf CellEditors#
-     */
-    editors: {}
-};
+});
 
 module.exports = CellEditors;

--- a/src/cellEditors/index.js
+++ b/src/cellEditors/index.js
@@ -50,4 +50,6 @@ var CellEditors = Registry.extend('CellEditors', {
 
 });
 
+CellEditors.add = Registry.prototype.add.bind(CellEditors);
+
 module.exports = CellEditors;

--- a/src/cellRenderers/index.js
+++ b/src/cellRenderers/index.js
@@ -50,4 +50,6 @@ var CellRenderers = Registry.extend('CellRenderers', {
 
 });
 
+CellRenderers.add = Registry.prototype.add.bind(CellRenderers);
+
 module.exports = CellRenderers;

--- a/src/cellRenderers/index.js
+++ b/src/cellRenderers/index.js
@@ -1,95 +1,53 @@
 'use strict';
 
+var Registry = require('../lib/Registry');
+
+
+var deprecated = {
+    emptycell: undefined,
+    EmptyCell: undefined
+};
+
+
 /**
- * @classdesc API of cell renderer object constructors, plus some access methods.
+ * @classdesc Registry of cell renderer singletons.
  * @param {boolean} [privateRegistry=false] - This instance will use a private registry.
  * @constructor
  */
-function CellRenderers(privateRegistry) {
-    if (privateRegistry) {
-        this.singletons = {};
-    }
+var CellRenderers = Registry.extend('CellRenderers', {
 
-    // preregister the standard cell renderers
-    if (privateRegistry || !this.get('emptycell')) {
-        this.add('EmptyCell', require('./CellRenderer'));
-        this.add(require('./Button'));
-        this.add(require('./SimpleCell'));
-        this.add(require('./SliderCell'));
-        this.add(require('./SparkBar'));
-        this.add(require('./LastSelection'));
-        this.add(require('./SparkLine'));
-        this.add(require('./ErrorCell'));
-        this.add(require('./TreeCell'));
-    }
-}
+    BaseClass: require('./CellRenderer'), // abstract base class
 
-CellRenderers.prototype = {
-    constructor: CellRenderers.prototype.constructor, // preserve constructor
+    items: {}, // shared cell renderer registry (when !options.private)
 
-    /**
-     * @summary Register and instantiate a cell renderer singleton.
-     * @desc Adds a custom cell renderer to the `singletons` hash using the provided name (or the class name), converted to all lower case.
-     *
-     * > All native cell renderers are "preregistered" in `singletons`. Add more by calling `add`.
-     *
-     * @param {string} [name] - Case-insensitive renderer key. If not given, `YourCellRenderer.prototype.$$CLASS_NAME` is used.
-     *
-     * @param {CellRenderer} Constructor - A constructor, typically extended from `CellRenderer` (or a descendant therefrom).
-     *
-     * > Note: `$$CLASS_NAME` can be easily set up by providing a string as the (optional) first parameter (`alias`) in your {@link https://www.npmjs.com/package/extend-me|CellEditor.extend} call.
-     *
-     * @returns {CellRenderers} A newly registered constructor extended from {@link CellRenderers}.
-     *
-     * @memberOf CellRenderers.prototype
-     */
-    add: function(name, Constructor) {
-        if (typeof name === 'function') {
-            Constructor = name;
-            name = undefined;
+    singletons: true,
+
+    initialize: function(options) {
+        // preregister the standard cell renderers
+        if (options && options.private || !this.items.simplecell) {
+            this.add(require('./Button'));
+            this.add(require('./SimpleCell'));
+            this.add(require('./SliderCell'));
+            this.add(require('./SparkBar'));
+            this.add(require('./LastSelection'));
+            this.add(require('./SparkLine'));
+            this.add(require('./ErrorCell'));
+            this.add(require('./TreeCell'));
         }
-
-        name = name || Constructor.prototype.$$CLASS_NAME;
-        name = name && name.toLowerCase();
-        return (this.singletons[name] = new Constructor);
     },
 
-    /**
-     * @summary Register a synonym for an existing cell renderer singleton.
-     * @param {string} synonymName
-     * @param {string} existingName
-     * @returns {CellRenderers} The previously registered constructor this new synonym points to.
-     * @memberOf CellRenderers.prototype
-     */
-    addSynonym: function(synonymName, existingName) {
-        var cellRenderer = this.get(existingName);
-        return (this.singletons[synonymName] = cellRenderer);
-    },
-
-    /**
-     * Fetch a registered cell renderer singleton.
-     * @param {string} name
-     * @returns {CellRenderers} A registered constructor extended from {@link CellRenderers}.
-     * @memberOf CellRenderers.prototype
-     */
     get: function(name) {
-        var result = this.singletons[name]; // for performance reasons, do not convert to lower case
-        if (!result) {
-            result = this.singletons[name.toLowerCase()]; // name may differ in case only
-            if (result) {
-                this.singletons[name] = result; // register found name as a synonym
+        if (name in deprecated) {
+            if (!deprecated.warned) {
+                console.warn('grid.cellRenderers.get("' + name + '").constructor has been deprecated as of v2.1.0 in favor of grid.cellRenderers.BaseClass property. (Will be removed in a future release.)');
+                deprecated.warned = true;
             }
+            this.BaseClass.constructor = this.BaseClass;
+            return this.BaseClass;
         }
-        return result;
-    },
+        return this.super.get.call(this, name);
+    }
 
-    /**
-     * The cell editor registry containing all the "preregistered" cell renderer singletons.
-     * @private
-     * @memberOf CellRenderers.prototype
-     */
-    singletons: {}
-};
-
+});
 
 module.exports = CellRenderers;

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1216,6 +1216,24 @@ var defaults = {
      */
     rowProperties: undefined,
 
+    /**
+     * Used to access registered features -- unless behavior has a non-empty `features` property (array of feature contructors).
+     */
+    features: [
+        'filters',
+        'cellselection',
+        'keypaging',
+        'columnresizing',
+        // 'rowresizing',
+        'rowselection',
+        'columnselection',
+        'columnmoving',
+        'columnsorting',
+        'cellclick',
+        'cellediting',
+        'onhover'
+    ],
+
     /** @summary How to truncate text.
      * @desc A "quaternary" value, one of:
      * * `undefined` - Text is not truncated.

--- a/src/features/Feature.js
+++ b/src/features/Feature.js
@@ -306,4 +306,8 @@ var Feature = Base.extend('Feature', {
 
 });
 
+
+Feature.abstract = true; // don't instantiate directly
+
+
 module.exports = Feature;

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -1,18 +1,58 @@
 'use strict';
 
-module.exports = {
-    Feature: require('./Feature'), // abstract base class
-    CellClick: require('./CellClick'),
-    CellEditing: require('./CellEditing'),
-    CellSelection: require('./CellSelection'),
-    ColumnMoving: require('./ColumnMoving'),
-    ColumnResizing: require('./ColumnResizing'),
-    ColumnSelection: require('./ColumnSelection'),
-    ColumnSorting: require('./ColumnSorting'),
-    Filters: require('./Filters'),
-    KeyPaging: require('./KeyPaging'),
-    OnHover: require('./OnHover'),
-    // RowResizing: require('./RowResizing'),
-    RowSelection: require('./RowSelection'),
-    ThumbwheelScrolling: require('./ThumbwheelScrolling')
-};
+var Registry = require('../lib/Registry');
+
+
+/**
+ * @classdesc Registry of feature constructors.
+ * @param {boolean} [privateRegistry=false] - This instance will use a private registry.
+ * @constructor
+ */
+var Features = Registry.extend('Features', {
+
+    BaseClass: require('./Feature'), // abstract base class
+
+    items: {}, // shared feature registry (when !options.private)
+
+    initialize: function(options) {
+        // preregister the standard cell renderers
+        if (options && options.private || !this.items.cellclick) {
+            this.add(require('./CellClick'));
+            this.add(require('./CellEditing'));
+            this.add(require('./CellSelection'));
+            this.add(require('./ColumnMoving'));
+            this.add(require('./ColumnResizing'));
+            this.add(require('./ColumnSelection'));
+            this.add(require('./ColumnSorting'));
+            this.add(require('./Filters'));
+            this.add(require('./KeyPaging'));
+            this.add(require('./OnHover'));
+            // this.add(require('./RowResizing'));
+            this.add(require('./RowSelection'));
+            this.add(require('./ThumbwheelScrolling'));
+        }
+    }
+
+});
+
+
+// Following shared props provided solely in support of build file usage, e.g., `fin.Hypergrid.features.yada`,
+// and are not meant to be used elsewhere.
+
+Features.Feature = require('./Feature'); // abstract base class
+Features.CellClick = require('./CellClick');
+Features.CellEditing = require('./CellEditing');
+Features.CellSelection = require('./CellSelection');
+Features.ColumnMoving = require('./ColumnMoving');
+Features.ColumnResizing = require('./ColumnResizing');
+Features.ColumnSelection = require('./ColumnSelection');
+Features.ColumnSorting = require('./ColumnSorting');
+Features.Filters = require('./Filters');
+Features.KeyPaging = require('./KeyPaging');
+Features.OnHover = require('./OnHover');
+// Features.RowResizing = require('./RowResizing');
+Features.RowSelection = require('./RowSelection');
+Features.ThumbwheelScrolling = require('./ThumbwheelScrolling');
+
+
+module.exports = Features;

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -35,6 +35,8 @@ var Features = Registry.extend('Features', {
 
 });
 
+Features.add = Registry.prototype.add.bind(Features);
+
 
 // Following shared props provided solely in support of build file usage, e.g., `fin.Hypergrid.features.yada`,
 // and are not meant to be used elsewhere.

--- a/src/lib/Registry.js
+++ b/src/lib/Registry.js
@@ -1,0 +1,123 @@
+'use strict';
+
+var Base = require('../Base');
+
+var Registry = Base.extend('Registry', {
+    /**
+     * @param {object} [options] - The following options can alternatively be set in the prototype of an extending class.
+     * @param {boolean} [options.singletons=false] - The registry will consist of singletons which will be instantiated as they are added.
+     * (Otherwise the registry consists of constructors which are instantiated later on as needed.)
+     * @param {boolean} [options.private=false] - This instance will use a private registry.
+     */
+    initialize: function(options) {
+        this.options = options;
+
+        if (this.option('private')) {
+            this.items = {};
+        }
+    },
+
+    option: function(key) {
+        return this.options && key in this.options ? this.options[key] : this[key];
+    },
+
+    /**
+     * @summary Register and instantiate a singleton.
+     * @desc Adds an item to the registry using the provided name (or the class name), converted to all lower case.
+     *
+     * > All native cell renderers are "preregistered" in `singletons`. Add more by calling `add`.
+     *
+     * @param {string} [name] - Case-insensitive renderer key. If not given, `YourCellRenderer.prototype.$$CLASS_NAME` is used.
+     *
+     * @param {CellRenderer} Constructor - A constructor, typically extended from `CellRenderer` (or a descendant therefrom).
+     *
+     * > Note: `$$CLASS_NAME` can be easily set up by providing a string as the (optional) first parameter (`alias`) in your {@link https://www.npmjs.com/package/extend-me|CellEditor.extend} call.
+     *
+     * @returns {CellRenderers} A newly registered constructor extended from {@link CellRenderers}.
+     *
+     * @memberOf CellRenderers.prototype
+     */
+    add: function(name, Constructor) {
+        if (typeof name === 'function') {
+            Constructor = name;
+            name = undefined;
+        }
+
+        name = name || Constructor.prototype.$$CLASS_NAME;
+
+        if (!name) {
+            throw new this.HypergridError('Expected a registration name.');
+        }
+
+        name = name.toLowerCase();
+
+        return (this.items[name] = this.option('singletons') ? this.construct(Constructor) : Constructor);
+    },
+
+    /**
+     * @summary Register a synonym for an existing singleton.
+     * @param {string} synonymName
+     * @param {string} existingName
+     * @returns {CellRenderers} The previously registered constructor this new synonym points to.
+     * @memberOf CellRenderers.prototype
+     */
+    addSynonym: function(synonymName, existingName) {
+        return (this.items[synonymName] = this.get(existingName));
+    },
+
+    /**
+     * Fetch a registered singleton.
+     * @param {string} name
+     * @returns {CellRenderers} A registered constructor extended from {@link CellRenderers}.
+     * @memberOf CellRenderers.prototype
+     */
+    get: function(name) {
+        var result = this.items[name]; // for performance reasons, do not convert to lower case
+
+        if (!result) {
+            var lowerName = name.toLowerCase();
+            result = this.items[lowerName]; // name may differ in case only
+            if (result) {
+                this.addSynonym(name, lowerName); // register found name as a synonym for faster access next time around to avoid converting to lower case again
+            }
+        }
+
+        if (!result) {
+            throw new this.HypergridError('Expected a registered ' + this.$$CLASS_NAME.toLowerCase() + ': "' + name + '"');
+        }
+
+        return result;
+    },
+
+    /**
+     * @summary Lookup registered item and return a new instance thereof.
+     * @returns New instance of the named item.
+     * @param {string} name - Name of a registered item.
+     * @param {string} [options] - Properties to add to the instantiated item primarily for `mustache` use.
+     * @memberOf CellEditors#
+     */
+    create: function(name, options) {
+        var Constructor = this.get(name);
+
+        if (Constructor.abstract) {
+            throw new this.HypergridError('Attempt to instantiate the abstract "' + name + '" class.');
+        }
+
+        return this.construct(Constructor, options);
+    },
+
+    construct: function(Constructor, options) {
+        options = Object.assign({}, this.options, options);
+        return new Constructor(Object.keys(options).length && options);
+    },
+
+    /**
+     * The shared registry. (Not used when `options.private` was truthy.)
+     * @private
+     * @memberOf CellRenderers.prototype
+     */
+    items: {}
+});
+
+
+module.exports = Registry;

--- a/src/lib/dynamicProperties.js
+++ b/src/lib/dynamicProperties.js
@@ -45,6 +45,21 @@ var dynamicPropertyDescriptors = {
     /**
      * @memberOf module:dynamicPropertyDescriptors
      */
+    features: {
+        enumerable: true,
+        get: function() {
+            return this.var.features;
+        },
+        set: function(features) {
+            this.var.features = features;
+            this.grid.behavior.initializeFeatureChain(features);
+            this.grid.allowEvents(this.grid.getRowCount());
+        }
+    },
+
+    /**
+     * @memberOf module:dynamicPropertyDescriptors
+     */
     gridRenderer: {
         enumerable: true,
         get: function() {

--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -26,7 +26,7 @@ module.exports = {
                 internal: internal,
                 listener: listener,
                 decorator: function(e) {
-                    if (self.allowEventHandlers){
+                    if (self.allowEventHandlers) {
                         listener(e);
                     }
                 }
@@ -87,10 +87,14 @@ module.exports = {
     },
 
     allowEvents: function(allow){
-        if ((this.allowEventHandlers = !!allow)){
-            this.behavior.featureChain.attachChain();
-        } else {
-            this.behavior.featureChain.detachChain();
+        this.allowEventHandlers = !!allow;
+
+        if (this.behavior.featureChain) {
+            if (allow){
+                this.behavior.featureChain.attachChain();
+            } else {
+                this.behavior.featureChain.detachChain();
+            }
         }
 
         this.behavior.changed();


### PR DESCRIPTION
A property-based alternative to `behavior.features`.

Now the feature chain can be specified by `grid.properties.features` which is an array of registered feature names.

The advantage of making it a serializable property is that the feature chain can now be persisted along with other grid properties.

Caveat: Feature chain is delicate and dependent on the order of features. This approach is useful for omitting or substituting features, so long as the basic order is retained. Rearrange the order at your own risk!

Overriding `Behavior.prototype.features`, an array of feature constructors, is still supported and will get priority. (Override can take form of assigning to prototype before grid instantiation or  subclassing behavior with an override in subclass's prototype, and handing that subclass to `Hypergrid` constructor, _etc._)