### PR TITLE
Removed double-click delay

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fin-hypergrid",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Canvas-based high-performance spreadsheet",
   "repository": {
     "type": "git",

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -900,6 +900,8 @@ var defaults = {
     editable: true,
 
     /**
+     * Edit cell on double-click rather than single-click.
+     *
      * @default
      * @type {boolean}
      * @memberOf module:defaults
@@ -907,11 +909,16 @@ var defaults = {
     editOnDoubleClick: true,
 
     /**
+     * Sort column on double-click rather than single-click.
+     *
+     * Used by:
+     * * feature/ColumnSorting.js to decide which event to respond to (if any, see `unsortabe`).
+     * * feature/ColumnSelection.js to decide whether or not to wait for double-click.
      * @default
-     * @type {number}
+     * @type {boolean}
      * @memberOf module:defaults
      */
-    doubleClickDelay: 325,
+    sortOnDoubleClick: true,
 
     /**
      * Grid-level property.
@@ -1228,6 +1235,7 @@ var defaults = {
      */
     truncateTextWithEllipsis: true
 };
+
 
 /** @typedef {string} cssColor
  * @see https://developer.mozilla.org/en-US/docs/Web/CSS/color_value

--- a/src/features/CellEditing.js
+++ b/src/features/CellEditing.js
@@ -15,25 +15,11 @@ var CellEditing = Feature.extend('CellEditing', {
      * @param {Object} event - the event details
      */
     handleDoubleClick: function(grid, event) {
-        if (
-            grid.properties.editOnDoubleClick &&
-            event.isDataCell
-        ) {
-            grid.onEditorActivate(event);
-        } else if (this.next) {
-            this.next.handleDoubleClick(grid, event);
-        }
+        edit.call(this, grid, event);
     },
 
     handleClick: function(grid, event) {
-        if (
-            !grid.properties.editOnDoubleClick &&
-            event.isDataCell
-        ) {
-            grid.onEditorActivate(event);
-        } else if (this.next) {
-            this.next.handleClick(grid, event);
-        }
+        edit.call(this, grid, event, true);
     },
 
     /**
@@ -70,5 +56,20 @@ var CellEditing = Feature.extend('CellEditing', {
     }
 
 });
+
+// Note: Keep ! in place to convert both sides to bool for
+// accurate equality test because either could be undefined.
+function edit(grid, event, onDoubleClick) {
+    if (
+        event.isDataCell &&
+        !event.getCellProperty('editOnDoubleClick') === !onDoubleClick // caution see note
+    ) {
+        grid.onEditorActivate(event);
+    }
+
+    if (this.next) {
+        this.next[onDoubleClick ? 'handleDoubleClick' : 'handleClick'](grid, event);
+    }
+}
 
 module.exports = CellEditing;

--- a/src/features/ColumnSorting.js
+++ b/src/features/ColumnSorting.js
@@ -13,18 +13,17 @@ var ColumnSorting = Feature.extend('ColumnSorting', {
      * @param {Hypergrid} grid
      * @param {Object} event - the event details
      */
+    handleClick: function(grid, event) {
+        sort.call(this, grid, event);
+    },
 
+    /**
+     * @memberOf ColumnSorting.prototype
+     * @param {Hypergrid} grid
+     * @param {Object} event - the event details
+     */
     handleDoubleClick: function(grid, event) {
-        var columnProperties;
-        if (
-            event.isHeaderCell &&
-            (columnProperties = grid.behavior.getColumnProperties(event.gridCell.x)) &&
-            !columnProperties.unsortable
-        ) {
-            grid.fireSyntheticColumnSortEvent(event.gridCell.x, event.primitiveEvent.detail.keys);
-        } else if (this.next) {
-            this.next.handleDoubleClick(grid, event);
-        }
+        sort.call(this, grid, event, true);
     },
 
     /**
@@ -50,5 +49,22 @@ var ColumnSorting = Feature.extend('ColumnSorting', {
     }
 
 });
+
+// Note: Keep ! in place to convert both sides to bool for
+// accurate equality test because either could be undefined.
+function sort(grid, event, onDoubleClick) {
+    var columnProperties;
+    if (
+        event.isHeaderCell &&
+        !(columnProperties = event.columnProperties).unsortable &&
+        !columnProperties.sortOnDoubleClick === !onDoubleClick // caution see note
+    ) {
+        grid.fireSyntheticColumnSortEvent(event.gridCell.x, event.primitiveEvent.detail.keys);
+    }
+
+    if (this.next) {
+        this.next[onDoubleClick ? 'handleDoubleClick' : 'handleClick'](grid, event);
+    }
+}
 
 module.exports = ColumnSorting;

--- a/src/lib/Canvas.js
+++ b/src/lib/Canvas.js
@@ -87,6 +87,9 @@ function Canvas(div, component) {
     this.addEventListener('click', function(e) {
         self.finclick(e);
     });
+    this.addEventListener('dblclick', function(e) {
+        self.findblclick(e);
+    });
     this.addEventListener('contextmenu', function(e) {
         self.fincontextmenu(e);
         e.preventDefault();
@@ -123,7 +126,6 @@ Canvas.prototype = {
     repeatKeyStartTime: 0,
     currentKeys: [],
     hasMouse: false,
-    lastDoubleClickTime: 0,
     dragEndTime: 0,
     lastRepaintTime: 0,
     currentPaintCount: 0,
@@ -388,27 +390,17 @@ Canvas.prototype = {
     },
 
     finclick: function(e) {
-        var delay = this.component.properties.doubleClickDelay;
-        if (delay < 100) {
-            dispatchClickEvent.call(this, e);
-        } else if (this.doubleClickTimer && Date.now() - this.lastClickTime < delay) {
-            //this is a double click...
-            clearTimeout(this.doubleClickTimer); // prevent click event
-            this.doubleClickTimer = undefined;
-            this.findblclick(e);
-        } else {
-            this.lastClickTime = Date.now();
-            this.doubleClickTimer = setTimeout(dispatchClickEvent.bind(this, e), delay);
-        }
+        this.mouseLocation = this.getLocal(e);
+        this.dispatchNewMouseKeysEvent(e, 'fin-canvas-click', {
+            isRightClick: this.isRightClick(e)
+        });
     },
 
     findblclick: function(e) {
         this.mouseLocation = this.getLocal(e);
-        this.lastDoubleClickTime = Date.now();
         this.dispatchNewMouseKeysEvent(e, 'fin-canvas-dblclick', {
             isRightClick: this.isRightClick(e)
         });
-        //console.log('dblclick', this.currentKeys);
     },
 
     getCharMap: function() {
@@ -501,24 +493,13 @@ Canvas.prototype = {
     },
 
     fincontextmenu: function(e) {
-        var delay = this.component.properties.doubleClickDelay;
-
         if (e.ctrlKey && this.currentKeys.indexOf('CTRL') === -1) {
             this.currentKeys.push('CTRL');
         }
 
-        if (delay < 100) {
-            dispatchContextMenuEvent.call(this, e);
-        } else if (this.doubleRightClickTimer && Date.now() - this.lastClickTime < delay) {
-            //this is a double click...
-            clearTimeout(this.doubleRightClickTimer); // prevent context menu event
-            this.doubleRightClickTimer = undefined;
-            this.findblclick(e);
-        } else {
-            this.lastClickTime = Date.now();
-
-            this.doubleRightClickTimer = setTimeout(dispatchContextMenuEvent.bind(this, e), delay);
-        }
+        this.dispatchNewMouseKeysEvent(e, 'fin-canvas-context-menu', {
+            isRightClick: this.isRightClick(e)
+        });
     },
 
     repaint: function() {
@@ -620,21 +601,6 @@ Canvas.prototype = {
         this.infoDiv.style.display = message ? 'block' : 'none';
     }
 };
-
-function dispatchClickEvent(e) {
-    this.doubleClickTimer = undefined;
-    this.mouseLocation = this.getLocal(e);
-    this.dispatchNewMouseKeysEvent(e, 'fin-canvas-click', {
-        isRightClick: this.isRightClick(e)
-    });
-}
-
-function dispatchContextMenuEvent(e) {
-    this.doubleRightClickTimer = undefined;
-    this.dispatchNewMouseKeysEvent(e, 'fin-canvas-context-menu', {
-        isRightClick: this.isRightClick(e)
-    });
-}
 
 function paintLoopFunction(now) {
     if (paintRequest) {

--- a/src/lib/dynamicProperties.js
+++ b/src/lib/dynamicProperties.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var warnedDoubleClickDelay;
+
 /**
  * @summary Dynamic grid property getter/setters.
  * @desc  Dynamic grid properties can make use of a _backing store._
@@ -127,6 +129,21 @@ var dynamicPropertyDescriptors = {
                 setCellPropertiesByColumnNameAndRowIndex.call(this, cellsHash);
                 this.grid.behavior.changed();
             }
+        }
+    },
+
+    // remove to expire warning:
+    doubleClickDelay: {
+        enumerable: true,
+        get: function() {
+            return this.var.doubleClickDelay;
+        },
+        set: function(delay) {
+            if (!warnedDoubleClickDelay) {
+                warnedDoubleClickDelay = true;
+                console.warn('The doubleClickDelay property has been deprecated as of v2.1.0. Setting this property no longer has any effect. Set double-click speed in your system\'s mouse preferences. (This warning will be removed in a future release.)');
+            }
+            this.var.doubleClickDelay = delay;
         }
     }
 };


### PR DESCRIPTION
> NOTE: This new PR replaces _Implement column sorting using single click_ (#654), which is now closed.

#### Defunct option `doubleClickDelay`

This PR removes the `doubleClickDelay` property so single-clicks are more responsive. The double-click delay is no longer defined in properties. Trying to set it results in a warning that it is now ineffective and the double-click delay is now system-dependent (_e.g.,_ in mouse control panel).

For the record, the defunct property defaulted to 325ms.

The naming of this property parallels the existing `editOnDoubleClick` property. Cell editing now respects cell's or column's property setting rather than relying exclusively on grid property setting.

#### New option: `sourtOnDoubleClick`
Also added an option to allow sort click to be single-click or double-click (previously was hard-coded to double-click). The new property `sortOnDoubleClick` defaults to `true`; change this to `false` for single-click.

When `false` (sort is single-click), both sorting and column selection toggling occur on the same click.

When `true` (sort is double-click), we have the very situation warned against on [the web](https://api.jquery.com/dblclick):

> It is inadvisable to bind handlers to both the click and dblclick events for the same element. ...

In this case (and only in this particular case) what we do is delay before responding to single click (for column selection). This is the only double-click delay remaining in the code base.

We cannot unfortunately read the system double-click delay so I have hard-coded the above delay to 300ms.