### PR TITLE
Lazify event selection props

### DIFF
--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -145,19 +145,11 @@ module.exports = {
      * @desc Synthesize and fire a `fin-row-selection-changed` event.
      */
     fireSyntheticRowSelectionChangedEvent: function() {
-        return dispatchEvent.call(this, 'fin-row-selection-changed', {
-            rows: this.getSelectedRows(),
-            columns: this.getSelectedColumns(),
-            selections: this.selectionModel.getSelections(),
-        });
-   },
+        return dispatchEvent.call(this, 'fin-row-selection-changed', this.selectionDetailGetters);
+    },
 
     fireSyntheticColumnSelectionChangedEvent: function() {
-        return dispatchEvent.call(this, 'fin-column-selection-changed', {
-            rows: this.getSelectedRows(),
-            columns: this.getSelectedColumns(),
-            selections: this.selectionModel.getSelections()
-        });
+        return dispatchEvent.call(this, 'fin-column-selection-changed', this.selectionDetailGetters);
     },
 
     /**
@@ -166,23 +158,17 @@ module.exports = {
      * @param {keyEvent} event - The canvas event.
      */
     fireSyntheticContextMenuEvent: function(event) {
-        event.rows = this.getSelectedRows();
-        event.columns = this.getSelectedColumns();
-        event.selections = this.selectionModel.getSelections();
+        Object.defineProperties(event, this.selectionDetailGetterDescriptors);
         return dispatchEvent.call(this, 'fin-context-menu', {}, event);
     },
 
     fireSyntheticMouseUpEvent: function(event) {
-        event.rows = this.getSelectedRows();
-        event.columns = this.getSelectedColumns();
-        event.selections = this.selectionModel.getSelections();
+        Object.defineProperties(event, this.selectionDetailGetterDescriptors);
         return dispatchEvent.call(this, 'fin-mouseup', {}, event);
     },
 
     fireSyntheticMouseDownEvent: function(event) {
-        event.rows = this.getSelectedRows();
-        event.columns = this.getSelectedColumns();
-        event.selections = this.selectionModel.getSelections();
+        Object.defineProperties(event, this.selectionDetailGetterDescriptors);
         return dispatchEvent.call(this, 'fin-mousedown', {}, event);
     },
 

--- a/src/lib/selection.js
+++ b/src/lib/selection.js
@@ -5,6 +5,27 @@
 var Rectangle = require('rectangular').Rectangle;
 
 module.exports = {
+    selectionInitialize: function() {
+        var grid = this;
+
+        /** for use by fin-selection-changed, fin-row-selection-changed, fin-column-selection-changed
+         * @memberOf Hypergrid#
+         * @private
+         */
+        this.selectionDetailGetters = {
+            get rows() { return grid.getSelectedRows(); },
+            get columns() { return grid.getSelectedColumns(); },
+            get selections() { return grid.selectionModel.getSelections(); }
+        };
+
+        /**
+         * for use by fin-context-menu, fin-mouseup, fin-mousedown
+         * @memberOf Hypergrid#
+         * @private
+         */
+        this.selectionDetailGetterDescriptors = Object.getOwnPropertyDescriptors(this.selectionDetailGetters);
+    },
+
     /**
      * @memberOf Hypergrid#
      * @returns {boolean} We have any selections.
@@ -506,11 +527,7 @@ module.exports = {
         this.selectColumnsFromCells();
 
         var selectionEvent = new CustomEvent('fin-selection-changed', {
-            detail: {
-                rows: this.getSelectedRows(),
-                columns: this.getSelectedColumns(),
-                selections: this.selectionModel.getSelections(),
-            }
+            detail: this.selectionDetailGetters
         });
         this.canvas.dispatchEvent(selectionEvent);
     },


### PR DESCRIPTION
These props are costly to run so should not run unless actually needed.

Even though these were only invoked rarely (on specific user interactions), they could be _very_ costly if a lot of rows/columns are involved, in terms of memory and execution time.