### PR TITLE
Hide row checkboxes & row numbers independently

### DIFF
--- a/demo/js/demo/index.js
+++ b/demo/js/demo/index.js
@@ -37,7 +37,6 @@ window.onload = function() {
         grid = window.grid = window.g = new Hypergrid('div#json-example', gridOptions),
         behavior = window.b = grid.behavior,
         dataModel = window.m = behavior.dataModel,
-        initial = true,
         idx = behavior.columnEnum;
 
 
@@ -78,17 +77,13 @@ window.onload = function() {
 
     function resetData() {
         setData(people1);
-        if (initial) {
-            initDashboard(demo, grid);
-            initial = false;
-        }
-        setTimeout(function() { initState(demo, grid); }, 50);
+        initState(demo, grid);
     }
-
-    resetData();
 
     initCellRenderers(demo, grid);
     initFormatters(demo, grid);
     initCellEditors(demo, grid);
     initEvents(demo, grid);
+    initDashboard(demo, grid);
+    initState(demo, grid);
 };

--- a/demo/js/demo/setState.js
+++ b/demo/js/demo/setState.js
@@ -147,46 +147,12 @@ module.exports = function(demo, grid) {
 
     grid.setState(state);
 
-    // properties that can be set
-    // use a function or a value
-
-    // font
-    // color
-    // backgroundColor
-    // foregroundSelectionColor
-    // backgroundSelectionColor
-
-    // columnHeaderFont
-    // columnHeaderColor
-    // columnHeaderBackgroundColor
-    // columnHeaderForegroundSelectionColor
-    // columnHeaderBackgroundSelectionColor
-
-    // rowHeaderFont
-    // rowHeaderColor
-    // rowHeaderBackgroundColor
-    // rowHeaderForegroundSelectionColor
-    // rowHeaderBackgroundSelectionColor
-
-    //                behavior.setCellProperties(idx.totalNumberOfPetsOwned, 0,
-    //                    {
-    //                        font: '10pt Tahoma',
-    //                        color: 'red',
-    //                        backgroundColor: 'lightblue',
-    //                        halign: 'left'
-    //                    });
-
     console.log('visible rows = ' + grid.renderer.visibleRows.map(function(vr){
         return vr.subgrid.type[0] + vr.rowIndex;
     }));
     console.log('visible columns = ' + grid.renderer.visibleColumns.map(function(vc){
         return vc.columnIndex;
     }));
-
-    //see myThemes.js file for how to create a theme
-    //grid.addProperties(myThemes.one);
-    //grid.addProperties(myThemes.two);
-    //grid.addProperties(myThemes.three);
 
     grid.takeFocus();
 

--- a/src/Hypergrid.js
+++ b/src/Hypergrid.js
@@ -269,16 +269,18 @@ var Hypergrid = Base.extend('Hypergrid', {
             var: { value: new Var() }
         });
 
-        // Deep clone all default props of object type, excluding dynamic props, so changes inside
-        // such objects won't affect theme or defaults layers which may be shared by other instances.
-        Object.keys(defaults)
-            .filter(function(key) { return !dynamicPropertyDescriptors[key]; })
-            .forEach(function(key) {
-                var value = Object.getOwnPropertyDescriptor(defaults, key).value; // do not invoke getters!
-                if (typeof value === 'object') {
-                    this[key] = deepClone(value);
+        // For all all default props of object type, if a dynamic prop, invoke setter; else deep clone it so changes
+        // made to inner props won't go to object on theme or defaults layers which are shared by other instances.
+        Object.keys(defaults).forEach(function(key) {
+            var value = defaults[key];
+            if (typeof value === 'object') {
+                if (dynamicPropertyDescriptors[key]) {
+                    this[key] = value; // invoke dynamic prop setter
+                } else {
+                    this[key] = deepClone(value); // just a plain object
                 }
-            }, this.properties);
+            }
+        }, this.properties);
     },
 
     /**

--- a/src/behaviors/Behavior.js
+++ b/src/behaviors/Behavior.js
@@ -170,6 +170,9 @@ var Behavior = Base.extend('Behavior', {
             index: rc,
             header: schema[rc].header
         });
+
+        // Signal the renderer to size the now-reset handle column before next render
+        this.grid.renderer.resetHandleColumnWidth();
     },
 
     getActiveColumn: function(x) {
@@ -1286,6 +1289,10 @@ var Behavior = Base.extend('Behavior', {
         };
     },
 
+    getHandleColumn: function() {
+        return this.allColumns[this.rowColumnIndex];
+    },
+
     autosizeAllColumns: function() {
         this.checkColumnAutosizing(true);
         this.changed();
@@ -1294,7 +1301,7 @@ var Behavior = Base.extend('Behavior', {
     checkColumnAutosizing: function(force) {
         force = force === true;
         var autoSized = this.autoSizeRowNumberColumn() ||
-            this.hasTreeColumn() && this.allColumns[this.rowColumnIndex].checkColumnAutosizing(force);
+            this.hasTreeColumn() && this.getHandleColumn().checkColumnAutosizing(force);
         this.allColumns.forEach(function(column) {
             autoSized = column.checkColumnAutosizing(force) || autoSized;
         });
@@ -1303,7 +1310,7 @@ var Behavior = Base.extend('Behavior', {
 
     autoSizeRowNumberColumn: function() {
         if (this.grid.properties.showRowNumbers && this.grid.properties.rowNumberAutosizing) {
-            return this.allColumns[this.rowColumnIndex].checkColumnAutosizing(true);
+            return this.getHandleColumn().checkColumnAutosizing(true);
         }
     },
 

--- a/src/behaviors/Column.js
+++ b/src/behaviors/Column.js
@@ -70,10 +70,6 @@ function Column(behavior, indexOrOptions) {
             this.properties.minimumColumnWidth = icon ? icon.width + 3 : 0;
             break;
         case this.behavior.rowColumnIndex:
-            // Width of icon + 3-pixel spacer (checked and unchecked should be same width)
-            icon = images[Object.create(this.properties.rowHeader, { isDataRow: { value: true } }).leftIcon];
-            this.properties.minimumColumnWidth = icon ? icon.width + 3 : 0;
-            // This case avoids the "out of range" error.
             break;
         default:
             if (index < 0) {

--- a/src/behaviors/columnProperties.js
+++ b/src/behaviors/columnProperties.js
@@ -111,20 +111,11 @@ function createColumnProperties() {
 
     });
 
-    Object.defineProperty(properties, 'rowHeader', {
-        value: Object.create(properties, createColumnProperties.rowHeaderDescriptors)
-    });
-
-    Object.defineProperty(properties, 'treeHeader', {
-        value: Object.create(properties, createColumnProperties.treeHeaderDescriptors)
-    });
-
-    Object.defineProperty(properties, 'columnHeader', {
-        value: Object.create(properties, createColumnProperties.columnHeaderDescriptors)
-    });
-
-    Object.defineProperty(properties, 'filterProperties', {
-        value: Object.create(properties, createColumnProperties.filterDescriptors)
+    Object.defineProperties(properties, {
+        rowHeader: { value: Object.create(properties, createColumnProperties.rowHeaderDescriptors) },
+        treeHeader: { value: Object.create(properties, createColumnProperties.treeHeaderDescriptors) },
+        columnHeader: { value: Object.create(properties, createColumnProperties.columnHeaderDescriptors) },
+        filterProperties: { value: Object.create(properties, createColumnProperties.filterDescriptors) }
     });
 
     return properties;
@@ -269,15 +260,17 @@ createColumnProperties.rowHeaderDescriptors = {
         configurable: true,
         enumerable: true,
         get: function() {
-            var result;
-            if (this.isDataRow) {
-                result = this.isRowSelected ? 'checked' : 'unchecked';
-            } else if (this.isHeaderRow) {
-                result = this.allRowsSelected ? 'checked' : 'unchecked';
-            } else if (this.isFilterRow) {
-                result = 'filter-off';
+            if (this.grid.properties.rowHeaderFeatures.checkboxes) {
+                var result;
+                if (this.isDataRow) {
+                    result = this.isRowSelected ? 'checked' : 'unchecked';
+                } else if (this.isHeaderRow) {
+                    result = this.allRowsSelected ? 'checked' : 'unchecked';
+                } else if (this.isFilterRow) {
+                    result = 'filter-off';
+                }
+                return result;
             }
-            return result;
         },
         set: function(value) {
             // replace self with a simple instance var

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -446,19 +446,31 @@ var defaults = {
      */
     renderFalsy: false,
 
-    /**
-     * @default
-     * @type {boolean}
+    /** @typedef gridLineProp
+     * @property {boolean} enabled
+     * @property {number} width
+     * @property {cssColor} color
+     */
+    /** @typedef gridLinesProp
+     * @property {gridLineProp} horizontal
+     * @property {gridLineProp} vertical
+     */
+    /** @type {gridLinesProp}
+     * @default '{ horizontal: { enabled: true, width: 1, color: rgb(199, 199, 199) }, vertical: { enabled: true, width: 1, color: rgb(199, 199, 199) }, }'
      * @memberOf module:defaults
      */
-    gridLinesH: true,
-
-    /**
-     * @default
-     * @type {boolean}
-     * @memberOf module:defaults
-     */
-    gridLinesV: true,
+    gridLines: {
+        horizontal: {
+            enabled: true,
+            width: 1,
+            color: 'rgb(199, 199, 199)'
+        },
+        vertical: {
+            enabled: true,
+            width: 1,
+            color: 'rgb(199, 199, 199)'
+        }
+    },
 
 
     /**
@@ -514,21 +526,6 @@ var defaults = {
      * @memberOf module:defaults
      */
     gridBorderBottom: true,
-
-    /**
-     * @default
-     * @type {cssColor}
-     * @memberOf module:defaults
-     */
-    lineColor: 'rgb(199, 199, 199)',
-
-    /**
-     * Caveat: `lineWidth` should be an integer (whole pixel)
-     * @default
-     * @type {number}
-     * @memberOf module:defaults
-     */
-    lineWidth: 1,
 
     /**
      * Define to make color of rule lines between fixed and scolling rows and columns different than `lineColor`.

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -777,38 +777,6 @@ var defaults = {
         return graphics.getTextHeight(font);
     },
 
-    get x() {
-        if (!warned.x) {
-            warned.x = true;
-            console.warn('config.x has been deprecated as of v1.2.10 in favor of config.dataCell.x. (Will be removed in a future release.)');
-        }
-        return this.dataCell.x;
-    },
-
-    get untranslatedX() {
-        if (!warned.untranslatedX) {
-            warned.untranslatedX = true;
-            console.warn('config.untranslatedX has been deprecated as of v1.2.10 in favor of config.gridCell.x. (Will be removed in a future release.)');
-        }
-        return this.gridCell.x;
-    },
-
-    get y() {
-        if (!warned.y) {
-            warned.y = true;
-            console.warn('config.y has been deprecated as of v1.2.10 in favor of config.gridCell.y. (Will be removed in a future release.)');
-        }
-        return this.gridCell.y;
-    },
-
-    get normalizedY() {
-        if (!warned.normalizedY) {
-            warned.normalizedY = true;
-            console.warn('config.normalizedY has been deprecated as of v1.2.10 in favor of config.dataCell.y. (Will be removed in a future release.)');
-        }
-        return this.dataCell.y;
-    },
-
     /**
      * @summary Execute value if "calculator" (function) or if column has calculator.
      * @desc This function is referenced here so:
@@ -838,8 +806,12 @@ var defaults = {
      * @default
      * @type {boolean}
      * @memberOf module:defaults
+     * @see {@link module:dynamicPropertyDescriptors.showRowHandleColumn}
      */
-    showRowNumbers: true,
+    rowHeaderFeatures: {
+        numbers: true,
+        checkboxes: true
+    },
 
     /**
      * @default

--- a/src/lib/dynamicProperties.js
+++ b/src/lib/dynamicProperties.js
@@ -147,6 +147,29 @@ var dynamicPropertyDescriptors = {
         }
     },
 
+    // The following grid line props are now dynamic (as of v2.1.0).
+    // They non-enumerable so they will not be output with `grid.saveState()`.
+    // The `gridLines` prop (new, as of 2.1.0) they refer to is output instead.
+    gridLinesH: {
+        get: function() { return this.gridLines.horizontal.enabled; },
+        set: function(enabled) { this.gridLines.horizontal.enabled = enabled; }
+    },
+
+    gridLinesV: {
+        get: function() { return this.gridLines.vertical.enabled; },
+        set: function(enabled) { this.gridLines.vertical.enabled = enabled; }
+    },
+
+    lineColor: {
+        get: function() { return this.gridLines.horizontal.color; },
+        set: function(color) { this.gridLines.horizontal.color = this.gridLines.vertical.color = color; }
+    },
+
+    lineWidth: {
+        get: function() { return this.gridLines.horizontal.width; },
+        set: function(width) { this.gridLines.horizontal.width = this.gridLines.vertical.width = width; }
+    },
+
     gridBorder: getGridBorderDescriptor(),
     gridBorderLeft: getGridBorderDescriptor('Left'),
     gridBorderRight: getGridBorderDescriptor('Right'),

--- a/src/lib/dynamicProperties.js
+++ b/src/lib/dynamicProperties.js
@@ -40,7 +40,11 @@ var dynamicPropertyDescriptors = {
             return this.var.subgrids;
         },
         set: function(subgrids) {
-            this.grid.behavior.subgrids = this.var.subgrids = subgrids;
+            this.var.subgrids = subgrids;
+
+            if (this.grid.behavior) {
+                this.grid.behavior.subgrids = subgrids;
+            }
         }
     },
 
@@ -132,6 +136,57 @@ var dynamicPropertyDescriptors = {
         }
     },
 
+    /**
+     * @memberOf module:dynamicPropertyDescriptors
+     */
+    rowHeaderFeatures: {
+        enumerable: true,
+        get: function() {
+            return this.var.rowHeaderFeatures;
+        },
+        set: function(rowHeaderFeatures) {
+            var grid = this.grid;
+            var features = Object.assign({}, this.var.rowHeaderFeatures = rowHeaderFeatures);
+            Object.defineProperties(rowHeaderFeatures, {
+                checkboxes: {
+                    get: function() {
+                        return features.checkboxes;
+                    },
+                    set: function(checkboxes) {
+                        features.checkboxes = checkboxes;
+                        grid.renderer.resetHandleColumnWidth();
+                    }
+                },
+                numbers: {
+                    get: function() {
+                        return features.numbers;
+                    },
+                    set: function(numbers) {
+                        features.numbers = numbers;
+                        grid.renderer.resetHandleColumnWidth();
+                    }
+                }
+            });
+            if (grid.renderer) {
+                grid.renderer.resetHandleColumnWidth();
+            } 
+        }
+    },
+
+    /**
+     * Legacy property; now points to both `rowHeaderFeatures` props.
+     * @memberOf module:dynamicPropertyDescriptors
+     */
+    showRowNumbers: {
+        enumerable: false,
+        get: function() {
+            return this.var.rowHeaderFeatures.checkboxes || this.var.rowHeaderFeatures.numbers;
+        },
+        set: function(enabled) {
+            this.var.rowHeaderFeatures.checkboxes = this.var.rowHeaderFeatures.numbers = enabled;
+        }
+    },
+
     // remove to expire warning:
     doubleClickDelay: {
         enumerable: true,
@@ -143,7 +198,7 @@ var dynamicPropertyDescriptors = {
                 warnedDoubleClickDelay = true;
                 console.warn('The doubleClickDelay property has been deprecated as of v2.1.0. Setting this property no longer has any effect. Set double-click speed in your system\'s mouse preferences. (This warning will be removed in a future release.)');
             }
-            this.var.doubleClickDelay = delay;
+            this.var.warnedDoubleClickDelay = delay;
         }
     },
 

--- a/src/lib/dynamicProperties.js
+++ b/src/lib/dynamicProperties.js
@@ -142,12 +142,16 @@ var dynamicPropertyDescriptors = {
     rowHeaderFeatures: {
         enumerable: true,
         get: function() {
-            return this.var.rowHeaderFeatures;
+            return this.var.rowHeaderFeatures || // from defaults or as subsequently set by setter
+                (this.var.rowHeaderFeatures = {}); // Init in case not in defaults
         },
         set: function(rowHeaderFeatures) {
             var grid = this.grid;
-            var features = Object.assign({}, this.var.rowHeaderFeatures = rowHeaderFeatures);
-            Object.defineProperties(rowHeaderFeatures, {
+            var features = Object.assign({}, rowHeaderFeatures); // clone values in closure
+
+            this.var.rowHeaderFeatures = rowHeaderFeatures; // override default
+
+            Object.defineProperties(rowHeaderFeatures, { // add setters to reset column width
                 checkboxes: {
                     get: function() {
                         return features.checkboxes;
@@ -167,9 +171,11 @@ var dynamicPropertyDescriptors = {
                     }
                 }
             });
+
             if (grid.renderer) {
+                // reset column width using new `features` values
                 grid.renderer.resetHandleColumnWidth();
-            } 
+            }
         }
     },
 
@@ -198,7 +204,7 @@ var dynamicPropertyDescriptors = {
                 warnedDoubleClickDelay = true;
                 console.warn('The doubleClickDelay property has been deprecated as of v2.1.0. Setting this property no longer has any effect. Set double-click speed in your system\'s mouse preferences. (This warning will be removed in a future release.)');
             }
-            this.var.warnedDoubleClickDelay = delay;
+            this.var.doubleClickDelay = delay;
         }
     },
 

--- a/src/renderer/by-rows.js
+++ b/src/renderer/by-rows.js
@@ -37,8 +37,9 @@ function paintCellsByRows(gc) {
         // clipToGrid,
         viewWidth = C ? visibleColumns[C - 1].right : 0,
         viewHeight = R ? visibleRows[R - 1].bottom : 0,
-        lineWidth = gridProps.lineWidth,
-        lineColor = gridProps.lineColor;
+        drawLines = gridProps.gridLines.horizontal.enabled,
+        lineWidth = gridProps.gridLines.horizontal.width,
+        lineColor = gridProps.gridLines.horizontal.color;
 
     gc.clearRect(0, 0, this.bounds.width, this.bounds.height);
 
@@ -68,7 +69,7 @@ function paintCellsByRows(gc) {
     for (p = 0, r = 0; r < R; r++) {
         prefillColor = rowPrefillColors[r];
 
-        if (gridProps.gridLinesH) {
+        if (drawLines) {
             gc.cache.fillStyle = lineColor;
             gc.fillRect(0, pool[p].visibleRow.bottom, viewWidth, lineWidth);
         }

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -242,7 +242,8 @@ var Renderer = Base.extend('Renderer', {
             insertionBoundsCursor = 0,
             previousInsertionBoundsCursorValue = 0,
 
-            lineWidth = grid.properties.lineWidth,
+            lineWidthHorizontal = grid.properties.gridLines.horizontal.width,
+            lineWidthVertical = grid.properties.gridLines.vertical.width,
 
             start = 0,
             numOfInternalCols = 0,
@@ -313,14 +314,15 @@ var Renderer = Base.extend('Renderer', {
 
             if (x) {
                 if ((gap = fixedColumnCount && c === fixedColumnCount)) {
-                    x += grid.properties.fixedLineWidth - lineWidth;
+                    x += grid.properties.fixedLineWidth - lineWidthVertical;
                 }
-                xSpaced = x + lineWidth;
-                widthSpaced = width - lineWidth;
+                xSpaced = x + lineWidthVertical;
+                widthSpaced = width - lineWidthVertical;
             } else {
                 xSpaced = x;
                 widthSpaced = width;
             }
+
             this.visibleColumns[c] = this.visibleColumnsByIndex[vx] = vc = {
                 index: c,
                 columnIndex: vx,
@@ -368,7 +370,7 @@ var Renderer = Base.extend('Renderer', {
                 vy = r;
                 if (scrollableSubgrid) {
                     if ((gap = fixedRowCount && r === fixedRowCount)) {
-                        y += grid.properties.fixedLineWidth - lineWidth;
+                        y += grid.properties.fixedLineWidth - lineWidthHorizontal;
                     }
                     if (r >= fixedRowCount) {
                         vy += scrollTop;
@@ -385,7 +387,7 @@ var Renderer = Base.extend('Renderer', {
                 rowIndex = vy - base;
                 height = behavior.getRowHeight(rowIndex, subgrid);
 
-                heightSpaced = height - lineWidth;
+                heightSpaced = height - lineWidthHorizontal;
                 this.visibleRows[r] = vr = {
                     index: r,
                     subgrid: subgrid,
@@ -1049,10 +1051,11 @@ var Renderer = Base.extend('Renderer', {
 
         if (C && R) {
             var gridProps = this.properties,
-                lineWidth = gridProps.lineWidth;
+                gridLines = gridProps.gridLines.vertical,
+                lineWidth = gridLines.width;
 
-            if (gridProps.gridLinesV) {
-                gc.cache.fillStyle = gridProps.lineColor;
+            if (gridLines.enabled) {
+                gc.cache.fillStyle = gridLines.color;
                 var viewHeight = visibleRows[R - 1].bottom;
                 for (var right, vc = visibleColumns[0], c = 1; c < C; c++) {
                     right = vc.right;
@@ -1065,8 +1068,11 @@ var Renderer = Base.extend('Renderer', {
                 }
             }
 
-            if (gridProps.gridLinesH) {
-                gc.cache.fillStyle = gridProps.lineColor;
+            gridLines = gridProps.gridLines.horizontal;
+            lineWidth = gridLines.width;
+
+            if (gridLines.enabled) {
+                gc.cache.fillStyle = gridLines.color;
                 var viewWidth = visibleColumns[C - 1].right;
                 for (var bottom, vr = visibleRows[0], r = 1; r < R; r++) {
                     bottom = vr.bottom;


### PR DESCRIPTION
To hide one feature or the other, reset the new properties `rowHeaderFeatures.checkboxes` and `rowHeaderFeatures.numbers`. If both are reset, the entire column is hidden.

Setting the legacy property `showRowNumbers` still hides and shows the entire column by setting both of the above. Getting the legacy property returns `true` if either of the above are set.

> NOTE: First commit below, 0e7eff6, belongs to PR #674; please review that PR first; don't comment here on edits coming from that commit.
  
  