### PR TITLE
v2.1.3 - Two more bugs shaken out

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ It also highlights a DOM-based custom external editor triggered via hypergrid ev
 * [Roadmap](#roadmap)
 * [Contributing](#contributors)
 
-### Current Release (2.1.2 - 29 January 2018)
+### Current Release (2.1.3 - 6 February 2018)
 
-**Hypergrid 2.1.2** includes bug fixes as well as some new properties and methods that offer new capabilities.
+**Hypergrid 2.1.3** includes bug fixes as well as some new properties and methods that offer new capabilities.
 
 _For a complete list of changes, see the [release notes](https://github.com/fin-hypergrid/core/releases)._
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -12,7 +12,7 @@
 
 </head>
 <body>
-    <h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.2 dev testbench</h1>
+    <h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.3 dev testbench</h1>
 
     <div id="tabs">
         <div id="tab-dashboard">Dashboard</div>

--- a/demo/multiple-grids.html
+++ b/demo/multiple-grids.html
@@ -5,7 +5,7 @@
     <style> body > div.hypergrid-container { width: 415px; margin-right: 10px; display: inline-block }</style>
 </head>
 <body>
-<h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.2 multiple grids demo</h1>
+<h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.3 multiple grids demo</h1>
 
 <script src="build/fin-hypergrid.js"></script>
 

--- a/demo/row-props.html
+++ b/demo/row-props.html
@@ -38,7 +38,7 @@
     </style>
 </head>
 <body>
-<h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.2 performance workbench</h1>
+<h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.3 performance workbench</h1>
 
 <div id="controls" class="nowrap">
     <label id="controller" title="Uncheck to hide other controls.">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fin-hypergrid",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fin-hypergrid",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Canvas-based high-performance grid",
   "repository": {
     "type": "git",

--- a/src/behaviors/Behavior.js
+++ b/src/behaviors/Behavior.js
@@ -759,7 +759,7 @@ var Behavior = Base.extend('Behavior', {
         }
 
         var metadata = (dataModel || this.dataModel).getRowMetadata(yOrCellEvent, properties && {});
-        return metadata && (metadata.__ROW || (metadata.__ROW = properties));
+        return metadata && (metadata.__ROW || properties && (metadata.__ROW = properties));
     },
 
     /**

--- a/src/behaviors/Behavior.js
+++ b/src/behaviors/Behavior.js
@@ -1086,7 +1086,7 @@ var Behavior = Base.extend('Behavior', {
      * @return {boolean} Can re-order columns.
      */
     isColumnReorderable: function() {
-        return this.grid.properties.columnsReorderable;
+        return this.deprecated('isColumnReorderable()', 'grid.properties.columnsReorderable', '2.1.3');
     },
 
     /**

--- a/src/behaviors/cellProperties.js
+++ b/src/behaviors/cellProperties.js
@@ -145,16 +145,16 @@ function getCellPropertiesObject(rowIndex, dataModel) {
  * @private
  */
 function newCellPropertiesObject(rowIndex, dataModel) {
-    var rowData = (dataModel || this.dataModel).getRow(rowIndex),
-        metadata = rowData.__META = rowData.__META || {},
-        props;
-
-    if (this._index >= 0) {
+    var metadata = (dataModel || this.dataModel).getRowMetadata(rowIndex, {}),
         props = this.properties;
-    } else if (this._index === this.behavior.treeColumnIndex) {
-        props = this.properties.treeHeader;
-    } else if (this._index === this.behavior.rowColumnIndex) {
-        props = this.properties.rowHeader;
+
+    switch (this._index) {
+        case this.behavior.treeColumnIndex:
+            props = this.properties.treeHeader;
+            break;
+        case this.behavior.rowColumnIndex:
+            props = this.properties.rowHeader;
+            break;
     }
 
     return (metadata[this.name] = Object.create(props));

--- a/src/cellEditors/index.js
+++ b/src/cellEditors/index.js
@@ -45,7 +45,7 @@ var CellEditors = Registry.extend('CellEditors', {
             }
             return this.BaseClass;
         }
-        return this.super.get.call(this, name);
+        return this.super.get.call(this, name, true);
     }
 
 });

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -13,6 +13,10 @@ var propClassEnum = {
     ROWS: 3,
     CELLS: 4
 };
+var propClassLayersMap = {
+    DEFAULT: [propClassEnum.COLUMNS, propClassEnum.STRIPES, propClassEnum.ROWS, propClassEnum.CELLS],
+    NO_ROWS: [propClassEnum.CELLS]
+};
 
 /**
  * This module lists the properties that can be set on a {@link Hypergrid} along with their default values.
@@ -1269,19 +1273,18 @@ var defaults = {
      */
     columnsReorderable: true,
 
-    /** @summary Apply cell properties before `getCell`.
-     * @type {boolean}
-     * @default
-     * @memberOf module:defaults
-     */
-    applyCellProperties: true,
-
     /** @summary Reapply cell properties after `getCell`.
      * @type {boolean}
      * @default
      * @memberOf module:defaults
      */
-    reapplyCellProperties: false,
+    set reapplyCellProperties(value) {
+        if (!warned.reapplyCellProperties) {
+            console.log('The `.reapplyCellProperties` property has been deprecated as of v2.1.3 in favor of using the new `.propClassLayers` property. (May be removed in a future version.) This property is now a setter which sets `.propClassLayers` to `.propClassLayersMap.DEFAULT` (grid ← columns ← stripes ← rows ← cells) on truthy or `propClassLayersMap.NO_ROWS` (grid ← columns ← cells) on falsy, which is what you will see on properties stringification. This will give the same effect in most cases as the former property implementation, but not in all cases due to it no longer being applied dynamically. Developers should discontinue use of this property and start specifying `.propClassLayers` instead.');
+            warned.reapplyCellProperties = true;
+        }
+        this.propClassLayers = value ? propClassLayersMap.NO_ROWS : propClassLayersMap.DEFAULT;
+    },
 
     /** @summary Column grab within this number of pixels from top of cell.
      * @type {number}
@@ -1331,7 +1334,8 @@ var defaults = {
 
     // for Renderer.prototype.assignProps
     propClassEnum: propClassEnum,
-    propClassLayers: [ propClassEnum.COLUMNS, propClassEnum.STRIPES, propClassEnum.ROWS, propClassEnum.CELLS ],
+    propClassLayersMap: propClassLayersMap,
+    propClassLayers: propClassLayersMap.DEFAULT,
 
     /**
      * Used to access registered features -- unless behavior has a non-empty `features` property (array of feature contructors).

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1280,7 +1280,7 @@ var defaults = {
      */
     set reapplyCellProperties(value) {
         if (!warned.reapplyCellProperties) {
-            console.log('The `.reapplyCellProperties` property has been deprecated as of v2.1.3 in favor of using the new `.propClassLayers` property. (May be removed in a future version.) This property is now a setter which sets `.propClassLayers` to `.propClassLayersMap.DEFAULT` (grid ← columns ← stripes ← rows ← cells) on truthy or `propClassLayersMap.NO_ROWS` (grid ← columns ← cells) on falsy, which is what you will see on properties stringification. This will give the same effect in most cases as the former property implementation, but not in all cases due to it no longer being applied dynamically. Developers should discontinue use of this property and start specifying `.propClassLayers` instead.');
+            console.warn('The `.reapplyCellProperties` property has been deprecated as of v2.1.3 in favor of using the new `.propClassLayers` property. (May be removed in a future version.) This property is now a setter which sets `.propClassLayers` to `.propClassLayersMap.DEFAULT` (grid ← columns ← stripes ← rows ← cells) on truthy or `propClassLayersMap.NO_ROWS` (grid ← columns ← cells) on falsy, which is what you will see on properties stringification. This will give the same effect in most cases as the former property implementation, but not in all cases due to it no longer being applied dynamically. Developers should discontinue use of this property and start specifying `.propClassLayers` instead.');
             warned.reapplyCellProperties = true;
         }
         this.propClassLayers = value ? propClassLayersMap.NO_ROWS : propClassLayersMap.DEFAULT;

--- a/src/features/CellEditing.js
+++ b/src/features/CellEditing.js
@@ -14,11 +14,16 @@ var CellEditing = Feature.extend('CellEditing', {
      * @param {Hypergrid} grid
      * @param {Object} event - the event details
      */
-    handleDoubleClick: function(grid, event) {
+    handleClick: function(grid, event) {
         edit.call(this, grid, event);
     },
 
-    handleClick: function(grid, event) {
+    /**
+     * @memberOf CellEditing.prototype
+     * @param {Hypergrid} grid
+     * @param {Object} event - the event details
+     */
+    handleDoubleClick: function(grid, event) {
         edit.call(this, grid, event, true);
     },
 
@@ -57,12 +62,10 @@ var CellEditing = Feature.extend('CellEditing', {
 
 });
 
-// Note: Keep ! in place to convert both sides to bool for
-// accurate equality test because either could be undefined.
 function edit(grid, event, onDoubleClick) {
     if (
         event.isDataCell &&
-        !event.getCellProperty('editOnDoubleClick') === !onDoubleClick // caution see note
+        !(event.getCellProperty('editOnDoubleClick') ^ onDoubleClick) // both same (true or falsy)?
     ) {
         grid.onEditorActivate(event);
     }

--- a/src/features/ColumnMoving.js
+++ b/src/features/ColumnMoving.js
@@ -158,7 +158,7 @@ var ColumnMoving = Feature.extend('ColumnMoving', {
      */
     handleMouseDown: function(grid, event) {
         if (
-            grid.behavior.isColumnReorderable() &&
+            grid.properties.columnsReorderable &&
             !event.isColumnFixed
         ) {
             if (event.isHeaderCell) {
@@ -207,7 +207,7 @@ var ColumnMoving = Feature.extend('ColumnMoving', {
      */
     handleMouseMove: function(grid, event) {
         if (
-            grid.behavior.isColumnReorderable() &&
+            grid.properties.columnsReorderable &&
             !event.isColumnFixed &&
             !this.dragging &&
             event.isHeaderCell &&

--- a/src/features/ColumnSorting.js
+++ b/src/features/ColumnSorting.js
@@ -50,14 +50,12 @@ var ColumnSorting = Feature.extend('ColumnSorting', {
 
 });
 
-// Note: Keep ! in place to convert both sides to bool for
-// accurate equality test because either could be undefined.
 function sort(grid, event, onDoubleClick) {
     var columnProperties;
     if (
         event.isHeaderCell &&
         !(columnProperties = event.columnProperties).unsortable &&
-        !columnProperties.sortOnDoubleClick === !onDoubleClick // caution see note
+        !(columnProperties.sortOnDoubleClick ^ onDoubleClick) // both same (true or falsy)?
     ) {
         grid.fireSyntheticColumnSortEvent(event.gridCell.x, event.primitiveEvent.detail.keys);
     }

--- a/src/lib/Registry.js
+++ b/src/lib/Registry.js
@@ -85,7 +85,7 @@ var Registry = Base.extend('Registry', {
         }
 
         if (!noThrow && !result) {
-            var classDesc = this.$$CLASS_NAME.replace(/[A-Z]/g, ' $1').trim().toLowerCase();
+            var classDesc = this.BaseClass.$$CLASS_NAME.replace(/([A-Z])/g, ' $1').trim().toLowerCase();
             throw new this.HypergridError('Expected "' + name + '" to be a registered ' + classDesc + '.');
         }
 

--- a/src/lib/cellEventFactory.js
+++ b/src/lib/cellEventFactory.js
@@ -10,19 +10,40 @@ var eumerableDescriptor = { writable: true, enumerable: true };
 // var nullSubgrid = {};
 
 factory.cellEventProperties = Object.defineProperties({}, {
+    /**
+     * The raw value of the cell, unformatted.
+     * @memberOf CellEvent#
+     */
     value: {
         get: function() { return this.subgrid.getValue(this.dataCell.x, this.dataCell.y); },
         set: function(value) { this.subgrid.setValue(this.dataCell.x, this.dataCell.y, value); }
     },
 
+    /**
+     * An object representing the whole data row, including hidden columns.
+     * @type {object}
+     * @memberOf CellEvent#
+     */
     dataRow: {
         get: function() { return this.subgrid.getRow(this.dataCell.y); }
     },
 
+    /**
+     * The formatted value of the cell.
+     * @memberOf CellEvent#
+     */
     formattedValue: {
         get: function() { return this.grid.formatValue(this.properties.format, this.value); }
     },
 
+    /**
+     * The bounds of the cell.
+     * @property {number} left
+     * @property {number} top
+     * @property {number} width
+     * @property {number} height
+     * @memberOf CellEvent#
+     */
     bounds: { get: function() {
         return this._bounds || (this._bounds = {
             x: this.visibleColumn.left,
@@ -58,13 +79,30 @@ factory.cellEventProperties = Object.defineProperties({}, {
         }
         return this._cellOwnProperties; // null return means there is no cell properties object
     } },
+    /**
+     * @returns {string} Cell properties object if it exists, else the column properties object it would have as a prototype if did exist.
+     * @method
+     * @memberOf CellEvent#
+     */
     properties: { get: function() {
         return this.cellOwnProperties || this.columnProperties;
     } },
+    /**
+     * @param {string} key - Property name.
+     * @returns {string} Property value.
+     * @method
+     * @memberOf CellEvent#
+     */
     getCellProperty: { value: function(key) {
         // included for completeness but `.properties[key]` is preferred
         return this.properties[key];
     } },
+    /**
+     * @param {string} key - Property name.
+     * @param {string} value - Property value.
+     * @method
+     * @memberOf CellEvent#
+     */
     setCellProperty: { value: function(key, value) {
         // do not use `.cellOwnProperties[key] = value` because object may be null (this method creates new object as needed)
         this._cellOwnProperties = this.column.setCellProperty(this.dataCell.y, key, value, this.subgrid);
@@ -96,7 +134,7 @@ factory.cellEventProperties = Object.defineProperties({}, {
         this.rowProperties[key] = value; // todo: call `stateChanged()` after refac-as-flags
     } },
 
-    // special methods for use by renderer which reuses cellEvent object for performance reasons
+    // special method for use by renderer which reuses cellEvent object for performance reasons
     reset: { value: function(visibleColumn, visibleRow) {
         // getter caches
         this._columnProperties = undefined;
@@ -128,6 +166,7 @@ factory.cellEventProperties = Object.defineProperties({}, {
      * @param {number} gridC - Horizontal grid cell coordinate adjusted for horizontal scrolling after fixed columns.
      * @param {number} gridY - Raw vertical grid cell coordinate.
      * @returns {boolean} Visibility.
+     * @method
      * @memberOf CellEvent#
      */
     resetGridCY: { value: function(gridC, gridY) {
@@ -145,6 +184,7 @@ factory.cellEventProperties = Object.defineProperties({}, {
      * @param {number} gridX - Raw horizontal grid cell coordinate.
      * @param {number} gridY - Raw vertical grid cell coordinate.
      * @returns {boolean} Visibility.
+     * @method
      * @memberOf CellEvent#
      */
     resetGridXY: { value: function(gridX, gridY) {
@@ -163,6 +203,7 @@ factory.cellEventProperties = Object.defineProperties({}, {
      * @param {number} dataY - Vertical data cell coordinate.
      * @param {dataModelAPI} [subgrid=this.behavior.subgrids.data]
      * @returns {boolean} Visibility.
+     * @method
      * @memberOf CellEvent#
      */
     resetDataXY: { value: function(dataX, dataY, subgrid) {
@@ -182,6 +223,7 @@ factory.cellEventProperties = Object.defineProperties({}, {
      * @param {dataModelAPI} [subgrid=this.behavior.subgrids.data]
      * @param {boolean} [useAllCells] - Search in all rows and columns instead of only rendered ones.
      * @returns {boolean} Visibility.
+     * @method
      * @memberOf CellEvent#
      */
     resetGridXDataY: { value: function(gridX, dataY, subgrid, useAllCells) {
@@ -218,6 +260,7 @@ factory.cellEventProperties = Object.defineProperties({}, {
      * Copy self with or without own properties
      * @param {boolan} [assign=false] - Copy the own properties to the clone.
      * @returns {CellEvent}
+     * @method
      * @memberOf CellEvent#
      */
     clone: { value: function(assign) {
@@ -243,50 +286,165 @@ factory.cellEventProperties = Object.defineProperties({}, {
         }
     },
 
-    // "Visible" means scrolled into view.
+    /** "Visible" means scrolled into view.
+     * @type {boolean}
+     * @memberOf CellEvent#
+     */
     isRowVisible:    { get: function() { return !!this.visibleRow; } },
+    /** "Visible" means scrolled into view.
+     * @type {boolean}
+     * @memberOf CellEvent#
+     */
     isColumnVisible: { get: function() { return !!this.visibleColumn; } },
+    /** "Visible" means scrolled into view.
+     * @type {boolean}
+     * @memberOf CellEvent#
+     */
     isCellVisible:   { get: function() { return this.isRowVisible && this.isColumnVisible; } },
 
+
+    /** A data row is any row in the data subgrid; all other rows (headers, footers, _etc._) are not data rows.
+     * @type {boolean}
+     * @memberOf CellEvent#
+     */
     isDataRow:    { get: function() { return this.subgrid.isData; } },
+    /** A data column is any column that is not the row number column or the tree column.
+     * @type {boolean}
+     * @memberOf CellEvent#
+     */
     isDataColumn: { get: function() { return this.gridCell.x >= 0; } },
+    /** A data cell is a cell in both a data row and a data column.
+     * @type {boolean}
+     * @memberOf CellEvent#
+     */
     isDataCell:   { get: function() { return this.isDataRow && this.isDataColumn; } },
 
+
+    /** @type {boolean}
+     * @memberOf CellEvent#
+     */
     isRowSelected:    { get: function() { return this.isDataRow && this.selectionModel.isRowSelected(this.dataCell.y); } },
+    /** @type {boolean}
+     * @memberOf CellEvent#
+     */
     isColumnSelected: { get: function() { return this.isDataColumn && this.selectionModel.isColumnSelected(this.gridCell.x); } },
+    /** @type {boolean}
+     * @memberOf CellEvent#
+     */
     isCellSelected:   { get: function() { return this.selectionModel.isCellSelected(this.gridCell.x, this.dataCell.y); } },
 
+
+    /** @type {boolean}
+     * @memberOf CellEvent#
+     */
     isRowHovered:    { get: function() { return this.grid.canvas.hasMouse && this.isDataRow && this.grid.hoverCell && this.grid.hoverCell.y === this.gridCell.y; } },
+    /** @type {boolean}
+     * @memberOf CellEvent#
+     */
     isColumnHovered: { get: function() { return this.grid.canvas.hasMouse && this.isDataColumn && this.grid.hoverCell && this.grid.hoverCell.x === this.gridCell.x; } },
+    /** @type {boolean}
+     * @memberOf CellEvent#
+     */
     isCellHovered:   { get: function() { return this.isRowHovered && this.isColumnHovered; } },
 
+
+    /** @type {boolean}
+     * @memberOf CellEvent#
+     */
     isRowFixed:    { get: function() { return this.isDataRow && this.dataCell.y < this.grid.properties.fixedRowCount; } },
+    /** @type {boolean}
+     * @memberOf CellEvent#
+     */
     isColumnFixed: { get: function() { return this.isDataColumn && this.gridCell.x < this.grid.properties.fixedColumnCount; } },
+    /** @type {boolean}
+     * @memberOf CellEvent#
+     */
     isCellFixed:   { get: function() { return this.isRowFixed && this.isColumnFixed; } },
 
+
+    /** @type {boolean}
+     * @memberOf CellEvent#
+     */
     isHandleColumn: { get: function() { return this.gridCell.x === this.behavior.rowColumnIndex && this.grid.properties.showRowNumbers; } },
+    /** @type {boolean}
+     * @memberOf CellEvent#
+     */
     isHandleCell:   { get: function() { return this.isHandleColumn && this.isDataRow; } },
 
+
+    /** @type {boolean}
+     * @memberOf CellEvent#
+     */
     isTreeColumn: { get: function() { return this.gridCell.x === this.behavior.treeColumnIndex; } },
 
+
+    /** @type {boolean}
+     * @memberOf CellEvent#
+     */
     isHeaderRow:    { get: function() { return this.subgrid.isHeader; } },
+    /** @type {boolean}
+     * @memberOf CellEvent#
+     */
     isHeaderHandle: { get: function() { return this.isHeaderRow && this.isHandleColumn; } },
+    /** @type {boolean}
+     * @memberOf CellEvent#
+     */
     isHeaderCell:   { get: function() { return this.isHeaderRow && this.isDataColumn; } },
 
+
+    /** @type {boolean}
+     * @memberOf CellEvent#
+     */
     isFilterRow:    { get: function() { return this.subgrid.isFilter; } },
+    /** @type {boolean}
+     * @memberOf CellEvent#
+     */
     isFilterHandle: { get: function() { return this.isFilterRow && this.isHandleColumn; } },
+    /** @type {boolean}
+     * @memberOf CellEvent#
+     */
     isFilterCell:   { get: function() { return this.isFilterRow && this.isDataColumn; } },
 
+
+    /** @type {boolean}
+     * @memberOf CellEvent#
+     */
     isSummaryRow:    { get: function() { return this.subgrid.isSummary; } },
+    /** @type {boolean}
+     * @memberOf CellEvent#
+     */
     isSummaryHandle: { get: function() { return this.isSummaryRow && this.isHandleColumn; } },
+    /** @type {boolean}
+     * @memberOf CellEvent#
+     */
     isSummaryCell:   { get: function() { return this.isSummaryRow && this.isDataColumn; } },
 
+
+    /** @type {boolean}
+     * @memberOf CellEvent#
+     */
     isTopTotalsRow:    { get: function() { return this.subgrid === this.behavior.subgrids.lookup.topTotals; } },
+    /** @type {boolean}
+     * @memberOf CellEvent#
+     */
     isTopTotalsHandle: { get: function() { return this.isTopTotalsRow && this.isHandleColumn; } },
+    /** @type {boolean}
+     * @memberOf CellEvent#
+     */
     isTopTotalsCell:   { get: function() { return this.isTopTotalsRow && this.isDataColumn; } },
 
+
+    /** @type {boolean}
+     * @memberOf CellEvent#
+     */
     isBottomTotalsRow:    { get: function() { return this.subgrid === this.behavior.subgrids.lookup.bottomTotals; } },
+    /** @type {boolean}
+     * @memberOf CellEvent#
+     */
     isBottomTotalsHandle: { get: function() { return this.isBottomTotalsRow && this.isHandleColumn; } },
+    /** @type {boolean}
+     * @memberOf CellEvent#
+     */
     isBottomTotalsCell:   { get: function() { return this.isBottomTotalsRow && this.isDataColumn; } },
 
     $$CLASS_NAME: { value: 'CellEvent' },
@@ -307,14 +465,7 @@ factory.cellEventProperties = Object.defineProperties({}, {
 });
 
 /**
- * @classdesc `CellEvent` is a very low-level object that needs to be super-efficient. JavaScript objects are well known to be light weight in general, but at this level we need to be careful.
- *
- * These objects were originally only being created on mouse events. This was no big deal as mouse events are few and far between. However, as of v1.2.0, the renderer now also creates one for each visible cell on each and every grid paint.
- *
- * For this reason, to maintain performance, each grid gets a custom definition of `CellEvent`, created by this class factory, with the following optimizations:
- *
- * * Use of `extend-me` is avoided because its `initialize` chain is a bit too heavy here.
- * * Custom versions of `CellEvent` for each grid lightens the load on the constructor.
+ * @name cellEventFactory
  *
  * @summary Create a custom `CellEvent` class.
  *
@@ -322,37 +473,50 @@ factory.cellEventProperties = Object.defineProperties({}, {
  *
  * @param {HyperGrid} grid
  *
- * @returns {CellEvent}
+ * @returns {function}
  */
 function factory(grid) {
 
     /**
      * @summary Create a new CellEvent object.
+     *
+     * @classdesc `CellEvent` is a very low-level object that needs to be super-efficient. JavaScript objects are well known to be light weight in general, but at this level we need to be careful.
+     *
+     * These objects were originally only being created on mouse events. This was no big deal as mouse events are few and far between. However, as of v1.2.0, the renderer now also creates one for each visible cell on each and every grid paint.
+     *
+     * For this reason, to maintain performance, each grid gets a custom definition of `CellEvent`, created by this class factory, with the following optimizations:
+     *
+     * * Use of `extend-me` is avoided because its `initialize` chain is a bit too heavy here.
+     * * Custom versions of `CellEvent` for each grid lightens the load on the constructor.
+     *
      * @desc All own enumerable properties are mixed into cell editor:
      * * Includes `this.column` defined by constructor (as enumerable).
      * * Excludes `this.gridCell`, `this.dataCell`, `this.visibleRow.subgrid` defined by constructor (as non-enumerable).
      * * Any additional (enumerable) members mixed in by application's `getCellEditorAt` override.
      *
-     * Including params calls {CellEvent#resetGridCY}.
-     * (See also the alternatives {@link CellEvent#resetGridXY}, {@link CellEvent#resetDataXY}, and {@link CellEvent#resetGridXDataY}.)
+     * Including the params calls {@link CellEvent#resetGridCY resetGridCY(gridX, gridY)}.
+     * Alternatively, instantiate without params and/or later call one of these:
+     * * {@link CellEvent#resetGridXY resetGridXY(...)}
+     * * {@link CellEvent#resetDataXY resetDataXY(...)}
+     * * {@link CellEvent#resetGridXDataY resetGridXDataY(...)}
      *
      * @param {number} [gridX] - grid cell coordinate (adjusted for horizontal scrolling after fixed columns).
      * @param {number} [gridY] - grid cell coordinate, adjusted (adjusted for vertical scrolling if data subgrid)
-     * @constructor
+     * @constructor CellEvent
      */
     function CellEvent(gridX, gridY) {
         // remaining instance vars are non-enumerable so `CellEditor` constructor won't mix them in (for mustache use).
         Object.defineProperties(this, {
             /**
              * @name visibleColumn
-             * @type {visibleColumnDescriptor}
+             * @type {visibleColumnArray}
              * @memberOf CellEvent#
              */
             visibleColumn: writableDescriptor,
 
             /**
              * @name visibleRow
-             * @type {visibleRowDescriptor}
+             * @type {visibleRowArray}
              * @memberOf CellEvent#
              */
             visibleRow: writableDescriptor,
@@ -366,6 +530,9 @@ function factory(grid) {
 
             /**
              * @name gridCell
+             * @property {number} x - The active column index, adjusted for column scrolling after fixed columns; _i.e.,_
+             * an index suitable for dereferencing the column object to which the cell belongs via {@link Behavior#getActiveColumn}.
+             * @property {number} y - The vertical grid coordinate, unaffected by subgrid, row scrolling, and fixed rows.
              * @type {WritablePoint}
              * @memberOf CellEvent#
              */
@@ -375,6 +542,9 @@ function factory(grid) {
 
             /**
              * @name dataCell
+             * @property {number} x - The data model's column index, unaffected by column scrolling; _i.e.,_
+             * an index suitable for dereferencing the column object to which the cell belongs via {@link Behavior#getColumn}.
+             * @property {number} y - The data model's row index, adjusted for data row scrolling after fixed rows.
              * @type {WritablePoint}
              * @memberOf CellEvent#
              */
@@ -382,7 +552,13 @@ function factory(grid) {
                 value: new WritablePoint
             },
 
-            // column is enumerable so it will be copied to cell event on CellEvent.prototype.initialize.
+            /**
+             * A reference to the {@link Column} object representing the column to which the cell belongs.
+             * @name column
+             * @type {Column}
+             * Enumerable so it will be copied to cell event on CellEvent.prototype.initialize.
+             * @memberOf CellEvent#
+             */
             column: eumerableDescriptor,
 
             // getter caches

--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -62,7 +62,11 @@ module.exports = {
         if (listenerList) {
             listenerList.find(function(info, index) {
                 if (info.listener === listener) {
-                    listenerList.splice(index, 1); // remove it from the list
+                    if (listenerList.length === 1) {
+                        delete this.listeners[eventName];
+                    } else {
+                        listenerList.splice(index, 1); // remove it from the list
+                    }
                     this.canvas.removeEventListener(eventName, info.decorator);
                     return true;
                 }
@@ -78,7 +82,7 @@ module.exports = {
      */
     removeAllEventListeners: function(internal) {
         _(this.listeners).each(function(listenerList, key) {
-            listenerList.forEach(function(info) {
+            listenerList.slice().forEach(function(info) {
                 if (internal || !info.internal) {
                     this.removeEventListener(key, info.listener);
                 }

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -4,25 +4,8 @@
 'use strict';
 
 var Base = require('../Base');
-var images = require('../../images/index');
-
-
-var propClassGet = [
-    undefined,
-    function(cellEvent) {
-        return cellEvent.columnProperties;
-    },
-    function(cellEvent) {
-        var rowStripes = cellEvent.isDataRow && cellEvent.columnProperties.rowStripes;
-        return rowStripes && rowStripes[cellEvent.dataCell.y % rowStripes.length];
-    },
-    function(cellEvent) {
-        return cellEvent.rowOwnProperties;
-    },
-    function(cellEvent) {
-        return cellEvent.cellOwnProperties;
-    }
-];
+var images = require('../../images');
+var layerProps = require('./layer-props');
 
 
 var visibleColumnPropertiesDescriptorFn = function(grid) {
@@ -1039,11 +1022,6 @@ var Renderer = Base.extend('Renderer', {
         // * mutate cell renderer choice (instance of which is returned)
         var cellRenderer = behavior.dataModel.getCell(config, config.renderer);
 
-        // Overwrite possibly mutated cell properties, if requested to do so by `getCell` override
-        if (cellEvent.cellOwnProperties && config.reapplyCellProperties) {
-            Object.assign(config, cellEvent.cellOwnProperties);
-        }
-
         behavior.cellPropertiesPrePaintNotification(config);
 
         //allow the renderer to identify itself if it's a button
@@ -1067,26 +1045,10 @@ var Renderer = Base.extend('Renderer', {
 
     /**
      * Overridable for alternative or faster logic.
-     * @param cellEvent
+     * @param CellEvent
+     * @returns {object} Layered config object.
      */
-    assignProps: function(cellEvent) {
-        var i, base, assignments,
-            propLayers = cellEvent.columnProperties.propClassLayers;
-
-        if (propLayers[0] !== 1) {
-            i = 0; // all prop layers
-            base = this.grid.properties;
-        } else {
-            i = 1; // skip column prop layer
-            base = cellEvent.columnProperties; // because column has grid properties as prototype
-        }
-
-        for (assignments = [Object.create(base)]; i < propLayers.length; ++i) {
-            assignments.push(propClassGet[propLayers[i]](cellEvent));
-        }
-
-        return Object.assign.apply(Object, assignments);
-    },
+    assignProps: layerProps,
 
     /**
      * @param {number|CellEvent} colIndexOrCellEvent - This is the "data" x coordinate.

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -78,7 +78,7 @@ var paintCellsFunctions = [];
  * @see [CanvasRenderingContext2D](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D)
  */
 
-/** @typedef {object} visibleColumnDescriptor
+/** @typedef {object} visibleColumnArray
  * @property {number} index - A back reference to the element's array index in {@link Renderer#visibleColumns}.
  * @property {number} columnIndex - Dereferences {@link Behavior#columns}, the subset of _active_ columns, specifying which column to show in that position.
  * @property {number} left - Pixel coordinate of the left edge of this column, rounded to nearest integer.
@@ -86,7 +86,7 @@ var paintCellsFunctions = [];
  * @property {number} width - Width of this column in pixels, rounded to nearest integer.
  */
 
-/** @typedef {object} visibleRowDescriptor
+/** @typedef {object} visibleRowArray
  * @property {number} index - A back reference to the element's array index in {@link Renderer#visibleRows}.
  * @property {number} rowIndex - Local vertical row coordinate within the subgrid to which the row belongs, adjusted for scrolling.
  * @property {dataModelAPI} subgrid - A reference to the subgrid to which the row belongs.
@@ -148,7 +148,7 @@ var Renderer = Base.extend('Renderer', {
          * 1. The first element will be -1 if the row handle column is being rendered.
          * 2. A zero-based list of consecutive of integers representing the fixed columns (if any).
          * 3. An n-based list of consecutive of integers representing the scrollable columns (where n = number of fixed columns + the number of columns scrolled off to the left).
-         * @type {visibleColumnDescriptor}
+         * @type {visibleColumnArray}
          */
         this.visibleColumns = Object.defineProperties([], visibleColumnPropertiesDescriptorFn(this.grid));
 
@@ -162,7 +162,7 @@ var Renderer = Base.extend('Renderer', {
          *   2. An n-based list of consecutive of integers representing the scrollable rows (where n = number of fixed rows + the number of rows scrolled off the top).
          *
          * Note that non-scrollable subgrids can come both before _and_ after the scrollable subgrid.
-         * @type {visibleRowDescriptor}
+         * @type {visibleRowArray}
          */
         this.visibleRows = [];
 

--- a/src/renderer/layer-props.js
+++ b/src/renderer/layer-props.js
@@ -1,0 +1,49 @@
+'use strict';
+
+var defaults = require('../defaults');
+
+var COLUMNS = defaults.propClassEnum.COLUMNS,
+    CELLS = defaults.propClassEnum.CELLS,
+    propClassGet = [];
+
+propClassGet[COLUMNS] = function(cellEvent) {
+    return cellEvent.columnProperties;
+};
+propClassGet[CELLS] = function(cellEvent) {
+    return cellEvent.cellOwnProperties;
+};
+propClassGet[defaults.propClassEnum.STRIPES] = function(cellEvent) {
+    var rowStripes = cellEvent.isDataRow && cellEvent.columnProperties.rowStripes;
+    return rowStripes && rowStripes[cellEvent.dataCell.y % rowStripes.length];
+};
+propClassGet[defaults.propClassEnum.ROWS] = function(cellEvent) {
+    return cellEvent.rowOwnProperties;
+};
+
+function assignProps(cellEvent) {
+    var i, base, assignments,
+        props = cellEvent.properties,
+        propLayers = props.propClassLayers;
+
+    switch (propLayers[0]) {
+        case COLUMNS:
+            i = 1; // skip column prop layer
+            base = cellEvent.columnProperties; // because column has grid props as prototype
+            break;
+        case CELLS:
+            i = 1; // skip cell prop layer
+            base = cellEvent.properties; // because cell has column props as prototype
+            break;
+        default:
+            i = 0; // all prop layers
+            base = this.grid.properties;
+    }
+
+    for (assignments = [Object.create(base)]; i < propLayers.length; ++i) {
+        assignments.push(propClassGet[propLayers[i]](cellEvent));
+    }
+
+    return Object.assign.apply(Object, assignments);
+}
+
+module.exports = assignProps;


### PR DESCRIPTION
## Another v2 update

In testing v3 candidate, I've stumbled upon a couple of additional bugs in v2 upon which v3 is based (now rebased).

This release is in keeping with our plan is to continue to maintain v2 for those users who are not ready to upgrade to v3.

## Details
* `17611ae` - **regression:** fixed double-click logic to not throw error on unknown cell editor. So if `properties.editor` contains a string unknown to `grid.cellEditors.get()` (internally, the list is kept in `grid.cellEditors.items`), before this fix an error was thrown; after this fix, the cell is  simply uneditable.
* `b133b31` - **bug:** fixes a long-standing, pre-existing bug that was causing `removeAllEventListeners` to throw an error. The problem was trying to use `each` (which uses `forEach`) to delete a list's own members. Solution was to clone the list for the benefit of `forEach`.
* `0576b50` - **jsdoc comments:** documented `CellEvent` (finally).
* `40194b9` - **no impact**: Code adjustment.
* `076047f ` - **version bump** 
* `8a9895a ` - **deprecation**: Deprecated `reapplyCellProperties` prop; added a layering dictionary. See the deprecation notice in the code for details. 
* `dd4c17a ` - **no impact**: Code adjustment. 