### PR TITLE
V2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ It also highlights a DOM-based custom external editor triggered via hypergrid ev
 * [Roadmap](#roadmap)
 * [Contributing](#contributors)
 
-### Current Release (2.1.4 - 20 February 2018)
+### Current Release (2.1.5 - 6 March 2018)
 
-**Hypergrid 2.1.4** includes bug fixes and new properties and methods that offer new capabilities.
+**Hypergrid 2.1.5** includes bug fixes.
 
 _For a complete list of changes, see the [release notes](https://github.com/fin-hypergrid/core/releases)._
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -12,7 +12,7 @@
 
 </head>
 <body>
-    <h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.4 dev testbench</h1>
+    <h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.5 dev testbench</h1>
 
     <div id="tabs">
         <div id="tab-dashboard">Dashboard</div>

--- a/demo/multiple-grids.html
+++ b/demo/multiple-grids.html
@@ -5,7 +5,7 @@
     <style> body > div.hypergrid-container { width: 415px; margin-right: 10px; display: inline-block }</style>
 </head>
 <body>
-<h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.4 multiple grids demo</h1>
+<h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.5 multiple grids demo</h1>
 
 <script src="build/fin-hypergrid.js"></script>
 

--- a/demo/row-props.html
+++ b/demo/row-props.html
@@ -38,7 +38,7 @@
     </style>
 </head>
 <body>
-<h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.4 performance workbench</h1>
+<h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.5 performance workbench</h1>
 
 <div id="controls" class="nowrap">
     <label id="controller" title="Uncheck to hide other controls.">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fin-hypergrid",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fin-hypergrid",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Canvas-based high-performance grid",
   "repository": {
     "type": "git",

--- a/src/Hypergrid.js
+++ b/src/Hypergrid.js
@@ -121,6 +121,8 @@ var Hypergrid = Base.extend('Hypergrid', {
          */
         this.cellEditors = new CellEditors({ grid: this });
 
+        this.initCanvas();
+
         if (this.options.Behavior) {
             this.setBehavior(this.options); // also sets this.options.pipeline and this.options.data
         } else if (this.options.data) {
@@ -797,7 +799,6 @@ var Hypergrid = Base.extend('Hypergrid', {
             // 2. Called from `setData` _and_ wasn't called explicitly since instantiation
             var Behavior = options.Behavior || behaviorJSON;
             this.behavior = new Behavior(this, options);
-            this.initCanvas();
             this.initScrollbars();
             this.refreshProperties();
             this.behavior.reindex();

--- a/src/behaviors/Behavior.js
+++ b/src/behaviors/Behavior.js
@@ -754,8 +754,8 @@ var Behavior = Base.extend('Behavior', {
      */
     getRowProperties: function(yOrCellEvent, properties, dataModel) {
         if (typeof yOrCellEvent === 'object') {
-            yOrCellEvent = yOrCellEvent.dataCell.y;
             dataModel = yOrCellEvent.subgrid;
+            yOrCellEvent = yOrCellEvent.dataCell.y;
         }
 
         var metadata = (dataModel || this.dataModel).getRowMetadata(yOrCellEvent, properties && {});
@@ -771,8 +771,8 @@ var Behavior = Base.extend('Behavior', {
      */
     setRowProperties: function(yOrCellEvent, properties, dataModel) {
         if (typeof yOrCellEvent === 'object') {
-            yOrCellEvent = yOrCellEvent.dataCell.y;
             dataModel = yOrCellEvent.subgrid;
+            yOrCellEvent = yOrCellEvent.dataCell.y;
         }
 
         (dataModel || this.dataModel).getRowMetadata(yOrCellEvent, {}, dataModel).__ROW = properties;


### PR DESCRIPTION
Draft of release notes:

* Fix a bug with a bug in `grid.behavior.getRowProperties()` and `.setRowProperties()` (new to 2.1).
* Fixed a bug where the `<canvas>` failed to be intialized when neither `options.Behavior` nor `options.data` are provided on grid instantiation (`new Hypergrid(options)`).

(These fixes have also been applied to v3.0.0 branch.)