### PR TITLE
v2.1.5 - fixed issue suppressing events on empty grid

### DIFF
--- a/src/Hypergrid.js
+++ b/src/Hypergrid.js
@@ -1769,6 +1769,22 @@ var Hypergrid = Base.extend('Hypergrid', {
         return this.behavior.getHeaderRowCount();
     },
 
+    /**
+     * @returns {number} The total number of rows of all subgrids following the data subgrid.
+     * @memberOf Hypergrid#
+     */
+    getFooterRowCount: function() {
+        return this.behavior.getFooterRowCount();
+    },
+
+    /**
+     * @returns {number} The total number of logical rows of all subgrids.
+     * @memberOf Hypergrid#
+     */
+    getLogicalRowCount: function() {
+        return this.behavior.getLogicalRowCount();
+    },
+
     isShowFilterRow: function() {
         return this.deprecated('isShowFilterRow()', 'properties.showFilterRow', 'v1.2.10');
     },

--- a/src/behaviors/Behavior.js
+++ b/src/behaviors/Behavior.js
@@ -1188,7 +1188,7 @@ var Behavior = Base.extend('Behavior', {
      */
     getFixedRowCount: function() {
         return (
-            this.grid.getHeaderRowCount() +
+            this.getHeaderRowCount() +
             this.grid.properties.fixedRowCount
         );
     },

--- a/src/behaviors/subgrids.js
+++ b/src/behaviors/subgrids.js
@@ -99,7 +99,7 @@ module.exports = {
 
     /**
      * @summary Gets the number of "header rows".
-     * @desc Defined as the sum of all rows of all subgrids before the (first) data subgrid.
+     * @desc Defined as the sum of all rows in all subgrids before the (first) data subgrid.
      * @memberOf behaviors.JSON.prototype
      */
     getHeaderRowCount: function() {
@@ -113,6 +113,34 @@ module.exports = {
         });
 
         return result;
+    },
+
+    /**
+     * @summary Gets the number of "footer rows".
+     * @desc Defined as the sum of all rows in all subgrids after the (last) data subgrid.
+     * @memberOf behaviors.JSON.prototype
+     */
+    getFooterRowCount: function() {
+        var gotData;
+        return this.subgrids.reduce(function(rows, subgrid) {
+            if (gotData && !subgrid.isData) {
+                rows += subgrid.getRowCount();
+            } else {
+                gotData = subgrid.isData;
+            }
+            return rows;
+        }, 0);
+    },
+
+    /**
+     * @summary Gets the total number of logical rows.
+     * @desc Defined as the sum of all rows in all subgrids.
+     * @memberOf behaviors.JSON.prototype
+     */
+    getLogicalRowCount: function() {
+        return this.subgrids.reduce(function(rows, subgrid) {
+            return (rows += subgrid.getRowCount());
+        }, 0);
     }
 };
 

--- a/src/features/ColumnMoving.js
+++ b/src/features/ColumnMoving.js
@@ -8,8 +8,8 @@
 
 var Feature = require('./Feature');
 
-var canDragCursorName = '-webkit-grab',
-    draggingCursorName = '-webkit-grabbing';
+var GRAB = 'grab',
+    GRABBING = 'grabbing';
 
 var columnAnimationTime = 150;
 var dragger;
@@ -163,7 +163,7 @@ var ColumnMoving = Feature.extend('ColumnMoving', {
         ) {
             if (event.isHeaderCell) {
                 this.dragArmed = true;
-                this.cursor = draggingCursorName;
+                this.cursor = GRABBING;
                 grid.clearSelections();
             }
         }
@@ -213,7 +213,7 @@ var ColumnMoving = Feature.extend('ColumnMoving', {
             event.isHeaderCell &&
             event.mousePoint.y < grid.properties.columnGrabMargin
         ) {
-            this.cursor = canDragCursorName;
+            this.cursor = GRAB;
         } else {
             this.cursor = null;
         }
@@ -223,7 +223,7 @@ var ColumnMoving = Feature.extend('ColumnMoving', {
         }
 
         if (event.isHeaderCell && this.dragging) {
-            this.cursor = draggingCursorName; //move';
+            this.cursor = GRABBING; //move';
         }
     },
 
@@ -386,7 +386,7 @@ var ColumnMoving = Feature.extend('ColumnMoving', {
 
         style.zIndex = '4';
         this.setCrossBrowserProperty(d, 'transform', 'translate(' + startX + 'px, ' + -2 + 'px)');
-        style.cursor = draggingCursorName;
+        style.cursor = GRABBING;
         grid.repaint();
     },
 
@@ -472,7 +472,7 @@ var ColumnMoving = Feature.extend('ColumnMoving', {
 
         this.setCrossBrowserProperty(d, 'transform', 'translate(' + x + 'px, -5px)');
         style.zIndex = '5';
-        style.cursor = draggingCursorName;
+        style.cursor = GRABBING;
         grid.repaint();
     },
 

--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -335,7 +335,7 @@ module.exports = {
         var self = this;
 
         function handleMouseEvent(e, cb) {
-            if (self.getRowCount() === 0) {
+            if (self.getLogicalRowCount() === 0) {
                 return;
             }
 

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -1282,15 +1282,7 @@ function computeCellsBounds() {
     }
 
     // get height of total number of rows in all subgrids following the data subgrid
-    footerHeight = gridProps.defaultRowHeight *
-        subgrids.reduce(function(rows, subgrid) {
-            if (scrollableSubgrid) {
-                rows += subgrid.getRowCount();
-            } else {
-                scrollableSubgrid = subgrid.isData;
-            }
-            return rows;
-        }, 0);
+    footerHeight = gridProps.defaultRowHeight * behavior.getFooterRowCount();
 
     for (
         base = r = g = y = 0, G = subgrids.length, Y = bounds.height - footerHeight;


### PR DESCRIPTION
Was suppressing events on empty data subgrid (scrollable portion) but should have been when _all_ subgrids were empty (no visible rows at all).

_Fix applied to v3 branch as well._