### PR TITLE
v2.1.6

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,7 +7,6 @@
 /doc
 /html/*.html
 /images/**
-!/images/index.js
 !/images/images.js
 /jsdoc-template-hypergrid
 /src/jsdoc
@@ -18,10 +17,12 @@
 /*.sh
 /*.md
 
-*.index.js
+index.js
 !/index.js
 !/css/index.js
+!/images/index.js
 !/src/cellRenderers/index.js
 !/src/cellEditors/index.js
+!/src/dataModels/index.js
 !/src/renderer/index.js
 !/src/features/index.js

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ It also highlights a DOM-based custom external editor triggered via hypergrid ev
 * [Roadmap](#roadmap)
 * [Contributing](#contributors)
 
-### Current Release (2.1.5 - 6 March 2018)
+### Current Release (2.1.6 - 16 March 2018)
 
-**Hypergrid 2.1.5** includes bug fixes.
+**Hypergrid 2.1.6** includes bug fixes.
 
 _For a complete list of changes, see the [release notes](https://github.com/fin-hypergrid/core/releases)._
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -12,7 +12,7 @@
 
 </head>
 <body>
-    <h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.5 dev testbench</h1>
+    <h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.6 dev testbench</h1>
 
     <div id="tabs">
         <div id="tab-dashboard">Dashboard</div>

--- a/demo/js/demo/index.js
+++ b/demo/js/demo/index.js
@@ -45,11 +45,9 @@ window.onload = function() {
     console.log('Indexes:'); console.dir(idx);
 
     function setData(data, options) {
-        options = !data.length ? undefined : options || {
-            schema: Hypergrid.lib.fields.getSchema(data)
-        };
+        options = Object.assign({}, options);
+        options.schema = options.schema || [];
         grid.setData(data, options);
-        behavior.reindex();
     }
 
     function reset() {

--- a/demo/js/demo/index.js
+++ b/demo/js/demo/index.js
@@ -27,10 +27,20 @@ window.onload = function() {
     // convert field names containing underscore to camel case by overriding column enum decorator
     Hypergrid.behaviors.JSON.prototype.columnEnumKey = Hypergrid.behaviors.JSON.columnEnumDecorators.toCamelCase;
 
+    var schema = Hypergrid.lib.fields.getSchema(people1);
+
+    // as of v2.1.6, column properties can also be initialized from custom schema (as well as from a grid state object).
+    // The following demonstrates this. Note that demo/setState.js also sets props of 'height' column. The setState
+    // call therein was changed to addState to accommodate (else schema props defined here would have been cleared).
+    Object.assign(schema.find(function(columnSchema) { return columnSchema.name === 'height'; }), {
+        halign: 'right',
+        // format: 'foot' --- for demo purposes, this prop being set in setState.js (see)
+    });
+
     var gridOptions = {
             data: people1,
             margin: { bottom: '17px', right: '17px'},
-            schema: Hypergrid.lib.fields.getSchema(people1),
+            schema: schema,
             plugins: require('fin-hypergrid-event-logger'),
             state: { color: 'orange' }
         },

--- a/demo/js/demo/setState.js
+++ b/demo/js/demo/setState.js
@@ -61,9 +61,19 @@ module.exports = function(demo, grid) {
             Add10: 'function(dataRow,columnName) { return dataRow[columnName] + 10; }'
         },
 
+        // ANTI-PATTERNS FOLLOW
+        //
+        // Setting column, row, cell props here in a state object is a legacy feature.
+        // Developers may find it more useful to set column props in column schema (as of v2.1.6),
+        // row props in row metadata (as of v2.1.0), and cell props in column metadata (as of v2.0.2),
+        // which would then persist across setState calls which clear these properties objects
+        // before applying new values. In this demo, we have changed the setState call below to addState
+        // (which does not clear the properties object first) to show how to set a column prop here *and*
+        // a different prop on the same column in schema (in index.js).
+
         columns: {
             height: {
-                halign: 'right',
+                // halign: 'right', --- for demo purposes, this prop being set in index.js (see)
                 format: 'foot'
             },
 
@@ -144,7 +154,7 @@ module.exports = function(demo, grid) {
         }
     };
 
-    grid.setState(state);
+    grid.addState(state); // changed from setState so 'height' props set with schema in index.js wouldn't be cleared
 
     grid.takeFocus();
 

--- a/demo/multiple-grids.html
+++ b/demo/multiple-grids.html
@@ -5,7 +5,7 @@
     <style> body > div.hypergrid-container { width: 415px; margin-right: 10px; display: inline-block }</style>
 </head>
 <body>
-<h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.5 multiple grids demo</h1>
+<h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.6 multiple grids demo</h1>
 
 <script src="build/fin-hypergrid.js"></script>
 

--- a/demo/row-props.html
+++ b/demo/row-props.html
@@ -38,7 +38,7 @@
     </style>
 </head>
 <body>
-<h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.5 performance workbench</h1>
+<h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.6 performance workbench</h1>
 
 <div id="controls" class="nowrap">
     <label id="controller" title="Uncheck to hide other controls.">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fin-hypergrid",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2024,12 +2024,9 @@
       "dev": true
     },
     "extend-me": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/extend-me/-/extend-me-2.6.0.tgz",
-      "integrity": "sha512-/2ZwOBxvriDEBkuBLUJGOoJVo+DoguQFdaOgZY1KAUTMEbn1YsVKMCaHWHbBRkNy5LDSeoHCJOm46YuvhspELw==",
-      "requires": {
-        "overrider": "0.3.0"
-      }
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/extend-me/-/extend-me-2.7.0.tgz",
+      "integrity": "sha512-SklO9LFB88+40BdgVOEx1Jhe9lA/+nEEB5Wop270Rhs3EGFRiGMJ3uatSuRGgTfQgub3HdALRPiAXvej4036gg=="
     },
     "extend-shallow": {
       "version": "2.0.1",
@@ -2138,7 +2135,7 @@
       "resolved": "https://registry.npmjs.org/fin-hypergrid-data-source-base/-/fin-hypergrid-data-source-base-0.4.11.tgz",
       "integrity": "sha1-coBp+maMibigGMsLpS7qsA8RFRo=",
       "requires": {
-        "extend-me": "2.6.0"
+        "extend-me": "2.7.0"
       }
     },
     "fin-hypergrid-event-logger": {
@@ -7655,6 +7652,9 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
+    },
+    "synonomous": {
+      "version": "file:../synonomous"
     },
     "syntax-error": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fin-hypergrid",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "Canvas-based high-performance grid",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "dependencies": {
     "chai": "^3.5.0",
-    "extend-me": "^2.3",
+    "extend-me": "^2.7.0",
     "fin-hypergrid-data-source-base": "^0.4.10",
     "fin-hypergrid-event-logger": "^1.0.3",
     "finbars": "1.5.2",
@@ -25,7 +25,8 @@
     "object-iterators": "1.3.0",
     "overrider": "^0",
     "rectangular": "1.0.1",
-    "sparse-boolean-array": "1.0.1"
+    "sparse-boolean-array": "1.0.1",
+    "synonomous": "^1.0.1"
   },
   "devDependencies": {
     "browser-sync": "^2.10.0",

--- a/src/behaviors/Behavior.js
+++ b/src/behaviors/Behavior.js
@@ -201,18 +201,16 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * The "grid index" given a "data index" (or column object)
+     * The "grid index" of an active column given a "data index" (number), column name (string), or column object
      * @param {Column|number} columnOrIndex
      * @returns {undefined|number} The grid index of the column or undefined if column not in grid.
      * @memberOf Hypergrid#
      */
-    getActiveColumnIndex: function(columnOrIndex) {
-        var index = columnOrIndex instanceof Column ? columnOrIndex.index : columnOrIndex;
-        for (var i = 0; i < this.columns.length; ++i) {
-            if (this.columns[i].index === index) {
-                return i;
-            }
-        }
+    getActiveColumnIndex: function(columnOrIndexOrName) {
+        var value = columnOrIndexOrName instanceof Column ? columnOrIndexOrName.index : columnOrIndexOrName,
+            key = typeof index === 'number' ? 'index' : 'name';
+
+        return this.columns.findIndex(function(column) { return column[key] === value; });
     },
 
     getVisibleColumn: function() {

--- a/src/behaviors/Behavior.js
+++ b/src/behaviors/Behavior.js
@@ -5,8 +5,10 @@ var Point = require('rectangular').Point;
 var Base = require('../Base');
 var Column = require('./Column');
 var cellEventFactory = require('../lib/cellEventFactory');
-var Features = require('../features');
+var featureRegistry = require('../features');
+var Synonomous = require('synonomous');
 var propClassEnum = require('../defaults.js').propClassEnum;
+var assignOrDelete = require('../lib/misc').assignOrDelete;
 
 
 var noExportProperties = [
@@ -42,6 +44,8 @@ var Behavior = Base.extend('Behavior', {
          */
         this.grid = grid;
 
+        this.synonomous = new Synonomous;
+
         this.initializeFeatureChain();
 
         this.grid.behavior = this;
@@ -72,7 +76,7 @@ var Behavior = Base.extend('Behavior', {
          */
         this.featureMap = {};
 
-        this.featureRegistry = this.featureRegistry || new Features;
+        this.featureRegistry = this.featureRegistry || featureRegistry;
 
         if (this.grid.properties.features) {
             var getFeatureConstructor = this.featureRegistry.get.bind(this.featureRegistry);
@@ -130,6 +134,9 @@ var Behavior = Base.extend('Behavior', {
         }
 
         this.scrollPositionX = this.scrollPositionY = 0;
+
+        this.rowPropertiesPrototype = Object.create(this.grid.properties,
+            require('./rowProperties').rowPropertiesPrototypeDescriptors);
 
         this.clearColumns();
         this.createColumns();
@@ -235,15 +242,21 @@ var Behavior = Base.extend('Behavior', {
     },
 
     addColumn: function(options) {
-        var column = this.newColumn(options);
-        this.columns.push(column);
-        this.allColumns.push(column);
+        var column = this.newColumn(options),
+            columns = this.columns,
+            allColumns = this.allColumns;
+
+        columns.push(column);
+        this.synonomous.decorateList(columns.length - 1, columns);
+
+        allColumns.push(column);
+        this.synonomous.decorateList(allColumns.length - 1, allColumns);
+
         return column;
     },
 
     createColumns: function() {
         this.clearColumns();
-        this.clearAllCellProperties();
         //concrete implementation here
     },
 
@@ -325,58 +338,99 @@ var Behavior = Base.extend('Behavior', {
      * @desc clear all table state
      */
     clearState: function() {
-       this.grid.clearState();
+        this.grid.clearState();
+        this.createColumns();
     },
 
     /**
      * @memberOf Behavior#
      * @desc Restore this table to a previous state.
      * See the [memento pattern](http://c2.com/cgi/wiki?MementoPattern).
-     * @param {Object} memento - an encapsulated representation of table state
+     * @param {Object} properties - assignable grid properties
      */
-    setState: function(memento) {
-
-        if (memento.rowHeights) {
-            this.deprecated('rowHeights', 'rowHeights, the hash of row heights you provided to setState method, is no longer supported as of v1.2.0 and will be ignored. Instead, for each row height you wish to set, use `rows: { subgrid: { y: { height: heightInPixels } } }` substituting the name (or type) of the subgrid for `subgrid`, the local zero-based rowIndex within the subgrid for `y`, and the row height in pixels for `heightInPixels`; or make individual calls to `setRowHeight(y, heightInPixels, dataModel)`. The dataModel arg is optional and defaults to this.dataModel (the data subgrid); specify to set row heights in other data models, such as header row, filter cell row, individual summary rows, etc.');
-        }
-
-        this.createColumns();
-
-        var state = this.grid.properties;
-        Object.keys(memento).forEach(function(key) {
-            state[key] = memento[key];
-        }, this);
-
-        this.setAllColumnProperties(memento.columnProperties);
-
-        this.dataModel.reindex();
+    setState: function(properties) {
+        this.addState(properties, true);
     },
 
-    setAllColumnProperties: function(columnProperties) {
-        if (columnProperties) {
-            columnProperties.forEach(function(properties, i) {
-                this.getColumn(i).properties = properties;
-            }, this);
+    /**
+     *
+     * @param {Object} properties - assignable grid properties
+     * @param {boolean} [settingState] - Clear properties object before assignments.
+     */
+    addState: function(properties, settingState) {
+        if (settingState) {
+            this.clearState();
         }
+
+        var gridProps = this.grid.properties;
+
+        gridProps.settingState = settingState;
+        assignOrDelete(gridProps, properties);
+        delete gridProps.settingState;
+
+        this.reindex();
+    },
+
+    /**
+     * @summary Sets properties for active columns.
+     * @desc Sets multiple columns' properties from elements of given array or collection. Keys may be column indexes or column names. The properties collection is cleared first. Falsy elements are ignored.
+     * @param {object[]|undefined} columnsHash - If undefined, this call is a no-op.
+     */
+    setAllColumnProperties: function(columnsHash) {
+        this.addAllColumnProperties(columnsHash, true);
+    },
+
+    /**
+     * @summary Adds properties for multiple columns.
+     * @desc Adds . The properties collection is optionally cleared first. Falsy elements are ignored.
+     * @param {object[]|undefined} columnsHash - If undefined, this call is a no-op.
+     * @param {boolean} [settingState] - Clear columns' properties objects before copying properties.
+     */
+    addAllColumnProperties: function(columnsHash, settingState) {
+        if (!columnsHash) {
+            return;
+        }
+
+        var columns = this.grid.behavior.getColumns();
+
+        Object.keys(columnsHash).forEach(function(key) {
+            var column = columns[key];
+            if (column) {
+                column.addProperties(columnsHash[key], settingState);
+            }
+        });
     },
 
     setColumnOrder: function(columnIndexes) {
         if (Array.isArray(columnIndexes)){
-            this.columns.length = columnIndexes.length;
-            columnIndexes.forEach(function(index, i) {
-                this.columns[i] = this.allColumns[index];
-            }, this);
+            var columns = this.columns,
+                allColumns = this.allColumns;
+
+            // avoid recreating the array to keep refs valid; just empty it (including name dictionary)
+            columns.length = 0;
+            var tc = this.treeColumnIndex.toString(), rc = this.rowColumnIndex.toString();
+            Object.keys(columns).forEach(function(key) {
+                switch (key) {
+                    case tc:
+                    case rc:
+                        break;
+                    default:
+                        delete columns[key];
+                }
+            });
+
+            columnIndexes.forEach(function(index) {
+                columns.push(allColumns[index]);
+            });
+
+            this.synonomous.decorateList(columns);
         }
     },
 
     setColumnOrderByName: function(columnNames) {
-        if (Array.isArray(columnNames)){
-            this.columns.length = columnNames.length;
-            columnNames.forEach(function(columnName, i) {
-                this.columns[i] = this.allColumns.find(function(column) {
-                    return column.name === columnName;
-                });
-            }, this);
+        if (Array.isArray(columnNames)) {
+            var allColumns = this.allColumns;
+            this.setColumnOrder(columnNames.map(function(name) { return allColumns[name].index; }));
         }
     },
 
@@ -718,128 +772,12 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @summary The total height of the "fixed rows."
-     * @desc The total height of all (non-scrollable) rows preceding the (scrollable) data subgrid.
-     * @memberOf Behavior#
-     * @return {number} The height in pixels of the fixed rows area of the hypergrid, the total height of:
-     * 1. All rows of all subgrids preceding the data subgrid.
-     * 2. The first `fixedRowCount` rows of the data subgrid.
-     */
-    getFixedRowsHeight: function() {
-        var dataModel, isData, r, R,
-            subgrids = this.subgrids,
-            height = 0;
-
-        for (var i = 0; i < subgrids.length && !isData; ++i) {
-            dataModel = subgrids[i];
-            isData = dataModel.isData;
-            R = isData ? this.grid.properties.fixedRowCount : dataModel.getRowCount();
-            for (r = 0; r < R; ++r) {
-                height += this.getRowHeight(r, dataModel);
-            }
-        }
-
-        return height;
-    },
-
-    /**
-     * @memberOf Behavior#
-     * @param {number|CellEvent} yOrCellEvent - Data row index local to `dataModel`; or a `CellEvent` object.
-     * @param {boolean} [properties] - New properties object when one does not already exist. If you don't provide this and one does not already exist, this call will return `undefined`. _(Required when 3rd param provided.)_
-     * @param {dataModelAPI} [dataModel=this.dataModel] - This is the subgrid. You only need to provide the subgrid when it is not the data subgrid _and_ you did not give a `CellEvent` object in the first param (which already knows what subgrid it's in).
-     * @returns {object|undefined} The row properties object which will be one of:
-     * * The row properties object if it existed.
-     * * The value you provided in `properties` if the row properties for a new row properties object when the object did not already exist in the metadata
-     * * `undefined` if the row properties object did not exist _and_ you did not provide a value in `properties`.
-     */
-    getRowProperties: function(yOrCellEvent, properties, dataModel) {
-        if (typeof yOrCellEvent === 'object') {
-            dataModel = yOrCellEvent.subgrid;
-            yOrCellEvent = yOrCellEvent.dataCell.y;
-        }
-
-        var metadata = (dataModel || this.dataModel).getRowMetadata(yOrCellEvent, properties && {});
-        return metadata && (metadata.__ROW || properties && (metadata.__ROW = properties));
-    },
-
-    /**
-     * Reset the row properties in its entirety to the given row properties object.
-     * @memberOf Behavior#
-     * @param {number|CellEvent} yOrCellEvent - Data row index local to `dataModel`; or a `CellEvent` object.
-     * @param {object} properties - The new row properties object.
-     * @param {dataModelAPI} [dataModel=this.dataModel] - This is the subgrid. You only need to provide the subgrid when it is not the data subgrid _and_ you did not give a `CellEvent` object in the first param (which already knows what subgrid it's in).
-     */
-    setRowProperties: function(yOrCellEvent, properties, dataModel) {
-        if (typeof yOrCellEvent === 'object') {
-            dataModel = yOrCellEvent.subgrid;
-            yOrCellEvent = yOrCellEvent.dataCell.y;
-        }
-
-        (dataModel || this.dataModel).getRowMetadata(yOrCellEvent, {}, dataModel).__ROW = properties;
-
-        this.stateChanged();
-    },
-
-    /**
-     * Sets a single row property on a specific individual row.
-     * @memberOf Behavior#
-     * @param {number|CellEvent} yOrCellEvent - Data row index local to `dataModel`; or a `CellEvent` object.
-     * @param {string} key - The property name.
-     * @param value - The new property value.
-     * @param {dataModelAPI} [dataModel=this.dataModel] - This is the subgrid. You only need to provide the subgrid when it is not the data subgrid _and_ you did not give a `CellEvent` object in the first param (which already knows what subgrid it's in).
-     */
-    setRowProperty: function(yOrCellEvent, key, value, dataModel) {
-        this.getRowProperties(yOrCellEvent, {}, dataModel)[key] = value;
-        this.stateChanged();
-    },
-
-    /**
-     * Add all the properties in the given row properties object to the row properties.
-     * @memberOf Behavior#
-     * @param {number|CellEvent} yOrCellEvent - Data row index local to `dataModel`; or a `CellEvent` object.
-     * @param {object} properties - An object containing new property values(s) to assign to the row properties.
-     * @param {dataModelAPI} [dataModel=this.dataModel] - This is the subgrid. You only need to provide the subgrid when it is not the data subgrid _and_ you did not give a `CellEvent` object in the first param (which already knows what subgrid it's in).
-     */
-    addRowProperties: function(yOrCellEvent, properties, dataModel) {
-        Object.assign(this.getRowProperties(yOrCellEvent, {}, dataModel), properties);
-        this.stateChanged();
-    },
-
-    /**
-     * @memberOf Behavior#
-     * @param {number} yOrCellEvent - Data row index local to `dataModel`.
-     * @param {dataModelAPI} [dataModel=this.dataModel]
-     */
-    getRowHeight: function(yOrCellEvent, dataModel) {
-        var rowProps = this.getRowProperties(yOrCellEvent, undefined, dataModel);
-        return rowProps && rowProps.height || this.grid.properties.defaultRowHeight;
-    },
-
-    /**
      * @memberOf Behavior#
      * @desc The value is lazily initialized and comes from the properties mechanism for '`defaultRowHeight`', which should be ~20px.
      * @returns {number} The row height in pixels.
      */
     getDefaultRowHeight: function() {
         return this.deprecated('getDefaultRowHeight()', 'grid.properties.defaultRowHeight', '1.2.0');
-    },
-
-    /**
-     * @memberOf Behavior#
-     * @desc set the pixel height of a specific row
-     * @param {number} yOrCellEvent - Data row index local to dataModel.
-     * @param {number} height - pixel height
-     * @param {dataModelAPI} [dataModel=this.dataModel]
-     */
-    setRowHeight: function(yOrCellEvent, height, dataModel) {
-        var rowProps = this.getRowProperties(yOrCellEvent, {}, dataModel),
-            oldHeight = rowProps.height;
-
-        rowProps.height = Math.max(5, Math.ceil(height));
-
-        if (rowProps.height !== oldHeight) {
-            this.stateChanged();
-        }
     },
 
     /**
@@ -1553,6 +1491,7 @@ Behavior.prototype.applyAnalytics = Behavior.prototype.reindex;
 
 // mix-ins
 Behavior.prototype.mixIn(require('./subgrids'));
+Behavior.prototype.mixIn(require('./rowProperties').mixin);
 
 
 module.exports = Behavior;

--- a/src/behaviors/JSON.js
+++ b/src/behaviors/JSON.js
@@ -40,12 +40,11 @@ var JSON = Behavior.extend('behaviors.JSON', {
         });
 
         this.dataModel.schema.forEach(function(columnSchema, index) {
-            this.addColumn({
-                index: index,
-                header: columnSchema.header,
-                calculator: columnSchema.calculator
-            });
-
+            if (typeof columnSchema === 'string') {
+                this.dataModel.schema[index] = columnSchema = { name: columnSchema };
+            }
+            columnSchema.index = index;
+            this.addColumn(columnSchema);
             columnEnum[this.columnEnumKey(columnSchema.name)] = index;
         }, this);
     },

--- a/src/behaviors/cellProperties.js
+++ b/src/behaviors/cellProperties.js
@@ -2,6 +2,9 @@
 
 'use strict';
 
+var assignOrDelete = require('../lib/misc').assignOrDelete;
+
+
 /**
  * Column.js mixes this module into its prototype.
  * @module
@@ -23,23 +26,26 @@ var cell = {
 
     /**
      * @param {number} rowIndex - Data row coordinate.
-     * @param {Object} properties - Hash of cell properties.
+     * @param {object|undefined} properties - Hash of cell properties. If `undefined`, this call is a no-op.
      * @returns {*}
      * @memberOf Column#
      */
     setCellProperties: function(rowIndex, properties, dataModel) {
-        return Object.assign(newCellPropertiesObject.call(this, rowIndex, dataModel), properties);
+        if (properties) {
+            return assignOrDelete(newCellPropertiesObject.call(this, rowIndex, dataModel), properties);
+        }
     },
 
     /**
      * @param {number} rowIndex - Data row coordinate.
-     * @param {Object} properties - Hash of cell properties.
-     * @param {boolean} [preserve=false] - Falsy creates new object; truthy copies `properties` members into existing object.
-     * @returns {*}
+     * @param {object|undefined} properties - Hash of cell properties. If `undefined`, this call is a no-op.
+     * @returns {object} Cell's own properties object, which will be created by this call if it did not already exist.
      * @memberOf Column#
      */
     addCellProperties: function(rowIndex, properties, dataModel) {
-        return Object.assign(getCellPropertiesObject.call(this, rowIndex, dataModel), properties);
+        if (properties) {
+            return assignOrDelete(getCellPropertiesObject.call(this, rowIndex, dataModel), properties);
+        }
     },
 
     /**

--- a/src/behaviors/columnProperties.js
+++ b/src/behaviors/columnProperties.js
@@ -443,4 +443,4 @@ createColumnProperties.columnHeaderDescriptors = {
     rightIcon: { writable: true, value: undefined},
 };
 
-module.exports.createColumnProperties = createColumnProperties;
+exports.createColumnProperties = createColumnProperties;

--- a/src/behaviors/rowProperties.js
+++ b/src/behaviors/rowProperties.js
@@ -1,0 +1,188 @@
+'use strict';
+
+exports.mixin = {
+    /**
+     * @summary The total height of the "fixed rows."
+     * @desc The total height of all (non-scrollable) rows preceding the (scrollable) data subgrid.
+     * @memberOf Behavior#
+     * @return {number} The height in pixels of the fixed rows area of the hypergrid, the total height of:
+     * 1. All rows of all subgrids preceding the data subgrid.
+     * 2. The first `fixedRowCount` rows of the data subgrid.
+     */
+    getFixedRowsHeight: function() {
+        var subgrid, isData, r, R,
+            subgrids = this.subgrids,
+            height = 0;
+
+        for (var i = 0; i < subgrids.length && !isData; ++i) {
+            subgrid = subgrids[i];
+            isData = subgrid.isData;
+            R = isData ? this.grid.properties.fixedRowCount : subgrid.getRowCount();
+            for (r = 0; r < R; ++r) {
+                height += this.getRowHeight(r, subgrid);
+            }
+        }
+
+        return height;
+    },
+
+    /**
+     * @memberOf Behavior#
+     * @param {number|CellEvent} yOrCellEvent - Data row index local to `dataModel`; or a `CellEvent` object.
+     * @param {boolean} [prototype] - Prototype for a new properties object when one does not already exist. If you don't define this and one does not already exist, this call will return `undefined`.
+     * Typical defined value is `null`, which creates a plain object with no prototype, or `Object.prototype` for a more "natural" object.
+     * _(Required when 3rd param provided.)_
+     * @param {dataModelAPI} [dataModel=this.dataModel] - This is the subgrid. You only need to provide the subgrid when it is not the data subgrid _and_ you did not give a `CellEvent` object in the first param (which already knows what subgrid it's in).
+     * @returns {object|undefined} The row properties object which will be one of:
+     * * object - existing row properties object or new row properties object created from `prototype`; else
+     * * `false` - row found but no existing row properties object and `prototype` was not defined; else
+     * * `undefined` - no such row
+     */
+    getRowProperties: function(yOrCellEvent, prototype, dataModel) {
+        if (typeof yOrCellEvent === 'object') {
+            dataModel = yOrCellEvent.subgrid;
+            yOrCellEvent = yOrCellEvent.dataCell.y;
+        }
+
+        var metadata = (dataModel || this.dataModel).getRowMetadata(yOrCellEvent, prototype === undefined ? undefined : null);
+        return metadata && (metadata.__ROW || prototype !== undefined && (metadata.__ROW = Object.create(prototype)));
+    },
+
+    /**
+     * Reset the row properties in its entirety to the given row properties object.
+     * @memberOf Behavior#
+     * @param {number|CellEvent} yOrCellEvent - Data row index local to `dataModel`; or a `CellEvent` object.
+     * @param {object|undefined} properties - The new row properties object. If `undefined`, this call is a no-op.
+     * @param {dataModelAPI} [dataModel=this.dataModel] - This is the subgrid. You only need to provide the subgrid when it is not the data subgrid _and_ you did not give a `CellEvent` object in the first param (which already knows what subgrid it's in).
+     */
+    setRowProperties: function(yOrCellEvent, properties, dataModel) {
+        if (!properties) {
+            return;
+        }
+
+        if (typeof yOrCellEvent === 'object') {
+            dataModel = yOrCellEvent.subgrid;
+            yOrCellEvent = yOrCellEvent.dataCell.y;
+        }
+
+        var metadata = (dataModel || this.dataModel).getRowMetadata(yOrCellEvent, null);
+        if (metadata) {
+            metadata.__ROW = Object.create(this.rowPropertiesPrototype);
+            this.addRowProperties(yOrCellEvent, properties, dataModel, metadata.__ROW);
+        }
+    },
+
+    /**
+     * Sets a single row property on a specific individual row.
+     * @memberOf Behavior#
+     * @param {number|CellEvent} yOrCellEvent - Data row index local to `dataModel`; or a `CellEvent` object.
+     * @param {string} key - The property name.
+     * @param value - The new property value.
+     * @param {dataModelAPI} [dataModel=this.dataModel] - This is the subgrid. You only need to provide the subgrid when it is not the data subgrid _and_ you did not give a `CellEvent` object in the first param (which already knows what subgrid it's in).
+     */
+    setRowProperty: function(yOrCellEvent, key, value, dataModel) {
+        var rowProps;
+        var isHeight = (key === 'height');
+
+        if (value !== undefined) {
+            rowProps = this.getRowProperties(yOrCellEvent, this.rowPropertiesPrototype, dataModel);
+            rowProps[key] = value;
+        } else {
+            // only try to undefine key if row props object exists; no point in creating it just to delete a non-existant key
+            rowProps = this.getRowProperties(yOrCellEvent, undefined, dataModel);
+            if (rowProps) {
+                delete rowProps[isHeight ? '_height' : key];
+            }
+        }
+
+        if (isHeight) {
+            this.shapeChanged();
+        } else {
+            this.stateChanged();
+        }
+    },
+
+    /**
+     * Add all the properties in the given row properties object to the row properties.
+     * @memberOf Behavior#
+     * @param {number|CellEvent} yOrCellEvent - Data row index local to `dataModel`; or a `CellEvent` object.
+     * @param {object|undefined} properties - An object containing new property values(s) to assign to the row properties. If `undefined`, this call is a no-op.
+     * @param {dataModelAPI} [dataModel=this.dataModel] - This is the subgrid. You only need to provide the subgrid when it is not the data subgrid _and_ you did not give a `CellEvent` object in the first param (which already knows what subgrid it's in).
+     */
+    addRowProperties: function(yOrCellEvent, properties, dataModel, rowProps) {
+        if (!properties) {
+            return;
+        }
+
+        var isHeight, hasHeight;
+
+        rowProps = rowProps || this.getRowProperties(yOrCellEvent, this.rowPropertiesPrototype, dataModel);
+
+        if (rowProps) {
+            Object.keys(properties).forEach(function(key) {
+                var value = properties[key];
+                if (value !== undefined) {
+                    rowProps[key] = value;
+                } else {
+                    isHeight = key === 'height';
+                    delete rowProps[isHeight ? '_height' : key];
+                    hasHeight = hasHeight || isHeight;
+                }
+            });
+
+            if (hasHeight) {
+                this.shapeChanged();
+            } else {
+                this.stateChanged();
+            }
+        }
+    },
+
+    /**
+     * @memberOf Behavior#
+     * @param {number} yOrCellEvent - Data row index local to `dataModel`.
+     * @param {dataModelAPI} [dataModel=this.dataModel]
+     * @returns {number} The row height in pixels.
+     */
+    getRowHeight: function(yOrCellEvent, dataModel) {
+        var rowProps = this.getRowProperties(yOrCellEvent, undefined, dataModel);
+        return rowProps && rowProps.height || this.grid.properties.defaultRowHeight;
+    },
+
+    /**
+     * @memberOf Behavior#
+     * @desc set the pixel height of a specific row
+     * @param {number} yOrCellEvent - Data row index local to dataModel.
+     * @param {number} height - pixel height
+     * @param {dataModelAPI} [dataModel=this.dataModel]
+     */
+    setRowHeight: function(yOrCellEvent, height, dataModel) {
+        this.setRowProperty(yOrCellEvent, 'height', height, dataModel);
+    }
+};
+
+
+exports.rowPropertiesPrototypeDescriptors = {
+    height: {
+        enumerable: true,
+        get: function() {
+            return this._height || this.defaultRowHeight;
+        },
+        set: function(height) {
+            height = Math.max(5, Math.ceil(height));
+            if (isNaN(height)) {
+                height = undefined;
+            }
+            if (height !== this._height) {
+                if (!height) {
+                    delete this._height;
+                } else {
+                    // Define `_height` as non-enumerable so won't be included in output of saveState.
+                    // (Instead the `height` getter is explicitly invoked and the result is included.)
+                    Object.defineProperty(this, '_height', { value: height, configurable: true });
+                }
+                this.grid.behaviorStateChanged();
+            }
+        }
+    }
+};

--- a/src/cellEditors/index.js
+++ b/src/cellEditors/index.js
@@ -3,53 +3,42 @@
 var Registry = require('../lib/Registry');
 
 
-var deprecated = {
-    celleditor: undefined,
-    CellEditor: undefined
-};
-
+var warnedBaseClass;
 
 /**
  * @classdesc Registry of cell editor constructors.
- * @param {Hypergrid} options.grid
- * @param {boolean} [options.private=false] - This instance will use a private registry.
  * @constructor
  */
 var CellEditors = Registry.extend('CellEditors', {
 
     BaseClass: require('./CellEditor'), // abstract base class
 
-    items: {}, // shared cell editor registry (when !options.private)
-
-    initialize: function(options) {
+    initialize: function() {
         // preregister the standard cell editors
-        if (options && options.private || !this.items.celleditor) {
-            this.add(require('./Color'));
-            this.add(require('./Date'));
-            this.add(require('./Number'));
-            this.add(require('./Slider'));
-            this.add(require('./Spinner'));
-            this.add(require('./Textfield'));
-        }
-    },
-
-    construct: function(Constructor, options) {
-        return new Constructor(this.options.grid, options);
+        this.add(require('./Color'));
+        this.add(require('./Date'));
+        this.add(require('./Number'));
+        this.add(require('./Slider'));
+        this.add(require('./Spinner'));
+        this.add(require('./Textfield'));
     },
 
     get: function(name) {
-        if (name in deprecated) {
-            if (!deprecated.warned) {
+        if (name && name.toLowerCase() === 'celleditor') {
+            if (!warnedBaseClass) {
                 console.warn('grid.cellEditors.get("' + name + '") method call has been deprecated as of v2.1.0 in favor of grid.cellEditors.BaseClass property. (Will be removed in a future release.)');
-                deprecated.warned = true;
+                warnedBaseClass = true;
             }
             return this.BaseClass;
         }
-        return this.super.get.call(this, name, true);
+        try {
+            var CellEditor = Registry.prototype.get.call(this, name);
+        } catch (err) {
+            // fail silently
+        }
+        return CellEditor;
     }
 
 });
 
-CellEditors.add = Registry.prototype.add.bind(CellEditors);
-
-module.exports = CellEditors;
+module.exports = new CellEditors;

--- a/src/cellRenderers/index.js
+++ b/src/cellRenderers/index.js
@@ -3,53 +3,50 @@
 var Registry = require('../lib/Registry');
 
 
-var deprecated = {
-    emptycell: undefined,
-    EmptyCell: undefined
-};
-
+var warnedBaseClass;
 
 /**
  * @classdesc Registry of cell renderer singletons.
- * @param {boolean} [privateRegistry=false] - This instance will use a private registry.
  * @constructor
  */
 var CellRenderers = Registry.extend('CellRenderers', {
 
     BaseClass: require('./CellRenderer'), // abstract base class
 
-    items: {}, // shared cell renderer registry (when !options.private)
-
-    singletons: true,
-
-    initialize: function(options) {
+    initialize: function() {
         // preregister the standard cell renderers
-        if (options && options.private || !this.items.simplecell) {
-            this.add(require('./Button'));
-            this.add(require('./SimpleCell'));
-            this.add(require('./SliderCell'));
-            this.add(require('./SparkBar'));
-            this.add(require('./LastSelection'));
-            this.add(require('./SparkLine'));
-            this.add(require('./ErrorCell'));
-            this.add(require('./TreeCell'));
+        this.add(require('./Button'));
+        this.add(require('./SimpleCell'));
+        this.add(require('./SliderCell'));
+        this.add(require('./SparkBar'));
+        this.add(require('./LastSelection'));
+        this.add(require('./SparkLine'));
+        this.add(require('./ErrorCell'));
+        this.add(require('./TreeCell'));
+    },
+
+    // for better performance, instantiate at add time rather than render time.
+    add: function(name, Constructor) {
+        if (arguments.length === 1) {
+            Constructor = name;
+            return Registry.prototype.add.call(this, new Constructor);
+        } else {
+            return Registry.prototype.add.call(this, name, new Constructor);
         }
     },
 
     get: function(name) {
-        if (name in deprecated) {
-            if (!deprecated.warned) {
+        if (name && name.toLowerCase() === 'emptycell') {
+            if (!warnedBaseClass) {
                 console.warn('grid.cellRenderers.get("' + name + '").constructor has been deprecated as of v2.1.0 in favor of grid.cellRenderers.BaseClass property. (Will be removed in a future release.)');
-                deprecated.warned = true;
+                warnedBaseClass = true;
             }
             this.BaseClass.constructor = this.BaseClass;
             return this.BaseClass;
         }
-        return this.super.get.call(this, name);
+        return Registry.prototype.get.call(this, name);
     }
 
 });
 
-CellRenderers.add = Registry.prototype.add.bind(CellRenderers);
-
-module.exports = CellRenderers;
+module.exports = new CellRenderers;

--- a/src/dataModels/DataModel.js
+++ b/src/dataModels/DataModel.js
@@ -19,14 +19,21 @@ var DataModel = Base.extend('DataModel', {
         return this.deprecated('getPrivateState()', 'grid.properties', '1.2.0');
     },
 
-    getRowMetadata: function(rowIndex, metadata) {
+    getRowMetadata: function(rowIndex, prototype) {
         var dataRow = this.getRow(rowIndex);
-        return dataRow && (dataRow.__META || (dataRow.__META = metadata));
+        return dataRow && (dataRow.__META || (prototype !== undefined && (dataRow.__META = Object.create(prototype))));
     },
 
     setRowMetadata: function(rowIndex, metadata) {
         var dataRow = this.getRow(rowIndex);
-        return dataRow && (dataRow.__META = metadata);
+        if (dataRow) {
+            if (metadata) {
+                dataRow.__META = metadata;
+            } else {
+                delete dataRow.__META;
+            }
+        }
+        return !!dataRow;
     },
 
     /**

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1354,6 +1354,22 @@ var defaults = {
         'onhover'
     ],
 
+    /** @summary Restore row selections across data transformations (`reindex` calls).
+     * @desc The restoration is based on the underlying data row indexes.
+     * @type {boolean}
+     * @default
+     * @memberOf module:defaults
+     */
+    restoreRowSelections: true,
+
+    /** @summary Restore column selections across data transformations (`reindex` calls).
+     * @desc The restoration is based on the column names.
+     * @type {boolean}
+     * @default
+     * @memberOf module:defaults
+     */
+    restoreColumnSelections: true,
+
     /** @summary How to truncate text.
      * @desc A "quaternary" value, one of:
      * * `undefined` - Text is not truncated.

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1092,10 +1092,9 @@ var defaults = {
     autoSelectColumns: false,
 
     /** @summary Name of a formatter for cell text.
-     * @desc The default (`undefined`) falls back to `column.type`.
-     * The value `null` does no formatting.
+     * @desc Unknown formatter falls back to the `string` formatter (simple conversion to string with `+ ''`).
      * @default undefined
-     * @type {undefined|null|string}
+     * @type {string}
      * @memberOf module:defaults
      * @tutorial localization
      */
@@ -1104,7 +1103,7 @@ var defaults = {
     /** @summary Name of a cell editor from the {@link module:cellEditors|cellEditors API}..
      * @desc Not editable if named editor is does not exist.
      * @default undefined
-     * @type {undefined|null|string}
+     * @type {string}
      * @memberOf module:defaults
      * @tutorial cell-editors
      */

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -12,36 +12,30 @@ var Features = Registry.extend('Features', {
 
     BaseClass: require('./Feature'), // abstract base class
 
-    items: {}, // shared feature registry (when !options.private)
-
-    initialize: function(options) {
+    initialize: function() {
         // preregister the standard cell renderers
-        if (options && options.private || !this.items.cellclick) {
-            this.add(require('./CellClick'));
-            this.add(require('./CellEditing'));
-            this.add(require('./CellSelection'));
-            this.add(require('./ColumnMoving'));
-            this.add(require('./ColumnResizing'));
-            this.add(require('./ColumnSelection'));
-            this.add(require('./ColumnSorting'));
-            this.add(require('./Filters'));
-            this.add(require('./KeyPaging'));
-            this.add(require('./OnHover'));
-            // this.add(require('./RowResizing'));
-            this.add(require('./RowSelection'));
-            this.add(require('./ThumbwheelScrolling'));
-        }
+        this.add(Features.CellClick);
+        this.add(Features.CellEditing);
+        this.add(Features.CellSelection);
+        this.add(Features.ColumnMoving);
+        this.add(Features.ColumnResizing);
+        this.add(Features.ColumnSelection);
+        this.add(Features.ColumnSorting);
+        this.add(Features.Filters);
+        this.add(Features.KeyPaging);
+        this.add(Features.OnHover);
+        // this.add(require('./RowResizing'));
+        this.add(Features.RowSelection);
+        this.add(Features.ThumbwheelScrolling);
     }
 
 });
 
-Features.add = Registry.prototype.add.bind(Features);
-
 
 // Following shared props provided solely in support of build file usage, e.g., `fin.Hypergrid.features.yada`,
-// and are not meant to be used elsewhere.
+// presumably for overriding built-in features, and are not meant to be used elsewhere.
 
-Features.Feature = require('./Feature'); // abstract base class
+Features.BaseClass = require('./Feature'); // abstract base class
 Features.CellClick = require('./CellClick');
 Features.CellEditing = require('./CellEditing');
 Features.CellSelection = require('./CellSelection');
@@ -57,4 +51,4 @@ Features.RowSelection = require('./RowSelection');
 Features.ThumbwheelScrolling = require('./ThumbwheelScrolling');
 
 
-module.exports = Features;
+module.exports = new Features;

--- a/src/lib/Registry.js
+++ b/src/lib/Registry.js
@@ -4,51 +4,41 @@ var Base = require('../Base');
 
 /**
  * @class
- * @param {object} [options] - The following options can alternatively be set in the prototype of an extending class.
- * @param {boolean} [options.singletons=false] - The registry will consist of singletons which will be instantiated as they are added.
- * (Otherwise the registry consists of constructors which are instantiated later on as needed.)
- * @param {boolean} [options.private=false] - This instance will use a private registry.
  */
 var Registry = Base.extend('Registry', {
-    initialize: function(options) {
-        this.options = options;
-
-        if (this.option('private')) {
-            this.items = Object.create(this.items);
-        }
-    },
-
-    option: function(key) {
-        return this.options && key in this.options ? this.options[key] : this[key];
+    initialize: function() {
+        this.items = Object.create(null);
     },
 
     /**
-     * @summary Register and instantiate a singleton.
+     * @summary Register an item and return it.
      * @desc Adds an item to the registry using the provided name (or the class name), converted to all lower case.
-     * @param {string} [name] - Case-insensitive item key. If not given, `Constructor.prototype.$$CLASS_NAME` is used.
-     * @param {function} Constructor
+     * @param {string} [name] - Case-insensitive item key. If not given, fallsback to `item.prototype.$$CLASS_NAME` or `item.prototype.name` or `item.name`.
+     * @param [item] - If unregistered or omitted, nothing is added and method returns `undefined`.
      *
      * > Note: `$$CLASS_NAME` is normally set by providing a string as the (optional) first parameter (`alias`) in your {@link https://www.npmjs.com/package/extend-me|extend} call.
      *
-     * @returns {function|Constructor} A newly registered item, either `Constructor` or singleton created by `new Constructor`.
+     * @returns Newly registered item or `undefined` if unregistered.
      *
      * @memberOf Registry#
      */
-    add: function(name, Constructor) {
-        if (typeof name === 'function') {
-            Constructor = name;
+    add: function(name, item) {
+        if (arguments.length === 1) {
+            item = name;
             name = undefined;
         }
 
-        name = name || Constructor.prototype.$$CLASS_NAME || Constructor.name; // try Funciton.prototype.name as last resort
-
-        if (!name) {
-            throw new this.HypergridError('Expected a registration name.');
+        if (!item) {
+            return;
         }
 
-        name = name.toLowerCase();
+        name = name || item.getClassName && item.getClassName();
 
-        return (this.items[name] = this.option('singletons') ? this.construct(Constructor) : Constructor);
+        if (!name) {
+            throw new this.HypergridError('Cannot register ' + this.friendlyName() + ' without a name.');
+        }
+
+        return (this.items[name] = item);
     },
 
     /**
@@ -63,13 +53,12 @@ var Registry = Base.extend('Registry', {
     },
 
     /**
-     * Fetch a registered singleton.
+     * Fetch a registered item.
      * @param {string} [name]
-     * @param {boolean} [noThrow] - Avoid throwing error if no such item; just return `undefined`.
-     * @returns {function|Constructor|undefined} A registered constructor item or `undefined` if none such.
+     * @returns {*|undefined} A registered item or `undefined` if unregistered.
      * @memberOf Registry#
      */
-    get: function(name, noThrow) {
+    get: function(name) {
         if (!name) {
             return;
         }
@@ -77,46 +66,53 @@ var Registry = Base.extend('Registry', {
         var result = this.items[name]; // for performance reasons, do not convert to lower case
 
         if (!result) {
-            var lowerName = name.toLowerCase();
-            result = this.items[lowerName]; // name may differ in case only
-            if (result) {
-                this.addSynonym(name, lowerName); // register found name as a synonym for faster access next time around to avoid converting to lower case again
-            }
-        }
+            var lowerName = name.toLowerCase(); // name may differ in case only
+            var foundName = Object.keys(this.items).find(function(key) { return lowerName === key.toLowerCase(); });
 
-        if (!noThrow && !result) {
-            var classDesc = this.BaseClass.$$CLASS_NAME.replace(/([A-Z])/g, ' $1').trim().toLowerCase();
-            throw new this.HypergridError('Expected "' + name + '" to be a registered ' + classDesc + '.');
+            result = this.items[foundName];
+
+            if (result) {
+                // Register name as a synonym for the found name for faster access next
+                // time without having to convert to lower case on every get.
+                this.addSynonym(name, foundName);
+            } else {
+                throw new this.HypergridError('Expected "' + name + '" to be a case-insensitive match for a registered ' + this.friendlyName() + '.');
+            }
         }
 
         return result;
     },
 
-    /**
-     * @summary Lookup registered item and return a new instance thereof.
-     * @returns New instance of the named constructor or `undefined` if none such.
-     * @param {string} name - Name of a registered item.
-     * @param {string} [options] - Properties to add to the instantiated item primarily for `mustache` use.
-     * @memberOf Registry#
-     */
-    create: function(name, options) {
-        var Constructor = this.get(name);
-
-        if (typeof Constructor !== 'function') {
-            return;
+    friendlyName: function() {
+        if (this.BaseClass) {
+            var name = this.BaseClass.getClassName();
+            name = name && name.replace(/([A-Z])/g, ' $1').trim().toLowerCase();
+        } else {
+            name = singularOf(this.getClassName()).toLowerCase();
         }
-
-        if (Constructor.abstract) {
-            throw new this.HypergridError('Attempt to instantiate the abstract "' + name + '" class.');
-        }
-
-        return this.construct(Constructor, options);
-    },
-
-    construct: function(Constructor, options) {
-        return new Constructor(Object.assign({}, this.options, options));
+        name = name || 'item';
+        return indefArtOf(name) + ' ' + name;
     }
 });
+
+var endings = [
+    { plural: /ies$/, singular: 'y' },
+    { plural: /s$/, singular: '' }
+];
+
+function singularOf(name) {
+    endings.find(function(ending) {
+        if (ending.plural.test(name)) {
+            name = name.replace(ending.plural, ending.singular);
+            return true;
+        }
+    });
+    return name;
+}
+
+function indefArtOf(name) {
+    return /^[aeiou]/.test(name) ? 'an' : 'a';
+}
 
 
 module.exports = Registry;

--- a/src/lib/cellEventFactory.js
+++ b/src/lib/cellEventFactory.js
@@ -111,17 +111,17 @@ factory.cellEventProperties = Object.defineProperties({}, {
     rowOwnProperties: {
         // undefined return means there is no row properties object
         get: function() {
-            return this.behavior.getRowProperties(this);
+            return this.behavior.getRowProperties(this, undefined, this.subgrid);
         }
     },
     rowProperties: {
         get: function() {
             // use carefully! creates new object as needed; only use when object definitely needed: for setting prop with `.rowProperties[key] = value` or `Object.assign(.rowProperties, {...})`; use getRowProperty(key) instead for getting a property that may not exist because it will not create a new object
-            return this.behavior.getRowProperties(this, {});
+            return this.behavior.getRowProperties(this, null, this.subgrid);
         },
         set: function(properties) {
             // for resetting whole row properties object: `.rowProperties = {...}`
-            this.behavior.setRowProperties(this, properties); // calls `stateChanged()`
+            this.behavior.setRowProperties(this, properties, this.subgrid); // calls `stateChanged()`
         }
     },
     getRowProperty: { value: function(key) {

--- a/src/lib/deprecated.js
+++ b/src/lib/deprecated.js
@@ -8,7 +8,7 @@ if (!console.warn) {
     };
 }
 
-var regexIsMethod = /^\w+\(.*\)$/;
+var regexIsMethod = /^[\w\.]+\(.*\)$/;
 
 /**
  * User is warned and new property is returned or new method is called and the result is returned.
@@ -44,7 +44,7 @@ var deprecated = function(methodName, dotProps, since, args, notes) {
         } else if (warned[methodName]) {
             --warned[methodName];
             memberType = regexIsMethod.test(dotProps) ? 'method' : 'property';
-            warning = 'The .' + methodName + ' method is deprecated as of v' + since +
+            warning = 'The .' + methodName + ' method has been deprecated as of v' + since +
                 ' in favor of the .' + chain.join('.') + ' ' + memberType + '.' +
                 ' (Will be removed in a future release.)';
 

--- a/src/lib/fields.js
+++ b/src/lib/fields.js
@@ -5,47 +5,23 @@
  * @module
  */
 
-var REGEXP_META_PREFIX = /^__/, // starts with double underscore
-    REGEXP_WORD_SEPARATORS = /[\s\-_]*([^\s\-_])([^\s\-_]+)/g,
-    REGEXP_CAPITAL_LETTERS = /[A-Z]/g,
-    REGEXP_LOWER_CASE_LETTER = /[a-z]/;
+var REGEXP_META_PREFIX = /^__/; // starts with double underscore
 
 /**
  * @param {object} hash
  * @returns {string[]} Member names from `hash` that do _not_ begin with double-underscore.
  * @memberOf module:fields
  */
-function getFieldNames(hash) {
+exports.getFieldNames = function(hash) {
     return Object.keys(hash || []).filter(function(fieldName) {
         return !REGEXP_META_PREFIX.test(fieldName);
     });
-}
+};
 
-function capitalize(a, b, c) {
-    return b.toUpperCase() + c;
-}
+exports.titleize = require('synonomous').prototype.toTitle;
 
-/**
- * Separates camel case or white-space-, hypen-, or underscore-separated-words into truly separate words and capitalizing the first letter of each.
- * @param string
- * @returns {string}
- * @memberOf module:fields
- */
-function titleize(string) {
-    return (REGEXP_LOWER_CASE_LETTER.test(string) ? string : string.toLowerCase())
-        .replace(REGEXP_WORD_SEPARATORS, capitalize)
-        .replace(REGEXP_CAPITAL_LETTERS, ' $&')
-        .trim();
-}
-
-function getSchema(data){
-    return getFieldNames(data && data[0] || {}).map(function(name) {
-        return { name: name, header: titleize(name) };
+exports.getSchema = function(data){
+    return exports.getFieldNames(data && data[0] || {}).map(function(name) {
+        return { name: name, header: exports.titleize(name) };
     });
-}
-
-module.exports = {
-    getFieldNames: getFieldNames,
-    titleize: titleize,
-    getSchema: getSchema
 };

--- a/src/lib/misc.js
+++ b/src/lib/misc.js
@@ -1,0 +1,29 @@
+'use strict';
+
+/**
+ * For each key in src:
+ * * When `src[key]` is defined, assigns it to `object[key]` when the latter does not exist or is writable or is a setter
+ * * When `src[key]` is undefined:
+ *    * When `object[key]` is a configurable property and not a setter, deletes it
+ *    * Else when `object[key]` is writable or is a setter, assigns `undefined` (setter handles deletion)
+ * @param {object} dest
+ * @param {object} src - Defined values set the corresponding key in `dest`. `undefined` values delete the key from `dest`.
+ */
+exports.assignOrDelete = function(dest, src) {
+    Object.keys(src).forEach(function(key) {
+        var descriptor = Object.getOwnPropertyDescriptor(dest, key),
+            value = src[key];
+
+        if (value !== undefined) {
+            if (!descriptor || descriptor.writable || descriptor.set) {
+                dest[key] = value;
+            }
+        } else if (descriptor) {
+            if (descriptor.configurable && !descriptor.set) {
+                delete dest[key];
+            } else if (descriptor.writable || descriptor.set) {
+                dest[key] = undefined;
+            }
+        } // else no descriptor so no property to delete
+    });
+};

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -1242,6 +1242,7 @@ function computeCellsBounds() {
 
         width = Math.ceil(behavior.getColumnWidth(vx));
 
+        gap = false;
         if (x) {
             if ((gap = hasFixedColumnGap && c === fixedColumnCount)) {
                 x += fixedWidthV - lineWidthV;
@@ -1256,6 +1257,7 @@ function computeCellsBounds() {
             left = x;
             widthSpaced = width;
         }
+
         this.visibleColumns[c] = this.visibleColumnsByIndex[vx] = vc = {
             index: c,
             columnIndex: vx,
@@ -1298,6 +1300,7 @@ function computeCellsBounds() {
         // For each row of each subgrid...
         for (R = r + subrows; r < R && y < Y; r++) {
             vy = r;
+            gap = false;
             if (scrollableSubgrid) {
                 if ((gap = hasFixedRowGap && r === fixedRowCount)) {
                     y += fixedWidthH - lineWidthH;


### PR DESCRIPTION
* Fixed COPY (ctrl-C, command-C) regression (copy select data command)
* Fixed single-column-after-fixed-column(s) render issue
* For restoring row selection(s) across data transformations (`reindex` calls):
   * Conditional upon new `restoreRowSelections` property (was formerly conditional upon `checkboxOnlyRowSelections` property)
   * Now also restores column selection(s), conditional upon new `restoreColumnSelections` property
* `Behavior.prototype.getActiveColumnIndex` now accepts a column name (string) (in addition to a data row index or column object)