### PR TITLE
Hypergrid v2.1.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It also highlights a DOM-based custom external editor triggered via hypergrid ev
 <img src="images/README/gridshot04.gif">
 
 ## Table of Contents
-* [Current Release](#current-release-217---14-april-2018)
+* [Current Release](#current-release-219---1-may-2018)
 * [Demos](#demos)
 * [Features](#features)
 * [Testing](#testing)
@@ -16,9 +16,9 @@ It also highlights a DOM-based custom external editor triggered via hypergrid ev
 * [Roadmap](#roadmap)
 * [Contributing](#contributors)
 
-### Current Release (2.1.8 - 24 April 2018)
+### Current Release (2.1.9 - 1 May 2018)
 
-**Hypergrid 2.1.8** includes bug fixes.
+**Hypergrid 2.1.9** includes bug fixes.
 
 _For a complete list of changes, see the [release notes](https://github.com/fin-hypergrid/core/releases)._
 
@@ -52,13 +52,13 @@ Find more information on our [testing page](TESTING.md)
 
 Primarily our tutorials will be on the [wiki](https://github.com/fin-hypergrid/core/wiki).
 
-We also maintain versioned [online API documentation](https://fin-hypergrid.github.io/core/2.1.8/doc/Hypergrid.html) for all public objects and modules. This documentation is necessarily an on-going work-in-progress.
+We also maintain versioned [online API documentation](https://fin-hypergrid.github.io/core/2.1.9/doc/Hypergrid.html) for all public objects and modules. This documentation is necessarily an on-going work-in-progress.
 
 (Cell editor information can be found [here](https://github.com/fin-hypergrid/core/wiki/Cell-Editors).)
 
 (Cell Rendering information can be found [here](https://github.com/fin-hypergrid/core/wiki/Cell-Renderers).)
 
-Hypergrid global configurations can be found [here](https://fin-hypergrid.github.io/core/2.1.8/doc/module-defaults.html).
+Hypergrid global configurations can be found [here](https://fin-hypergrid.github.io/core/2.1.9/doc/module-defaults.html).
 
 ### Roadmap
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -12,7 +12,7 @@
 
 </head>
 <body>
-    <h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.8 dev testbench</h1>
+    <h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.9 dev testbench</h1>
 
     <div id="tabs">
         <div id="tab-dashboard">Dashboard</div>

--- a/demo/multiple-grids.html
+++ b/demo/multiple-grids.html
@@ -5,7 +5,7 @@
     <style> body > div.hypergrid-container { width: 415px; margin-right: 10px; display: inline-block }</style>
 </head>
 <body>
-<h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.8 multiple grids demo</h1>
+<h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.9 multiple grids demo</h1>
 
 <script src="build/fin-hypergrid.js"></script>
 

--- a/demo/row-props.html
+++ b/demo/row-props.html
@@ -38,7 +38,7 @@
     </style>
 </head>
 <body>
-<h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.8 performance workbench</h1>
+<h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.9 performance workbench</h1>
 
 <div id="controls" class="nowrap">
     <label id="controller" title="Uncheck to hide other controls.">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fin-hypergrid",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fin-hypergrid",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "description": "Canvas-based high-performance grid",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fin-hypergrid",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "description": "Canvas-based high-performance grid",
   "repository": {
     "type": "git",

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -510,6 +510,30 @@ var defaults = {
     gridLinesVColor: 'rgb(199, 199, 199)',
 
     /**
+     * When {@link module:defaults.gridLinesV} is truthy, determines if lines render in the column headers area.
+     * @type {boolean}
+     * @default
+     * @memberOf module:defaults
+     */
+    gridLinesColumnHeader: true,
+
+    /**
+     * When {@link module:defaults.gridLinesH} is truthy, determines if lines render in the row headers area.
+     * @type {boolean}
+     * @default
+     * @memberOf module:defaults
+     */
+    gridLinesRowHeader: true,
+
+    /**
+     * When {@link module:defaults.gridLinesV} or {@link module:defaults.gridLinesH} are truthy, determines if lines render in the user data area.
+     * @type {boolean}
+     * @default
+     * @memberOf module:defaults
+     */
+    gridLinesUserDataArea: true,
+
+    /**
      * Set canvas's CSS border to this string as well as `gridBorderLeft`, `gridBorderRight`, `gridBorderTop`, and `gridBorderBottom`.
      * If set to `true`, uses current `lineWidth` and `lineColor`.
      * If set to `false`, uses null.

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -660,6 +660,7 @@ var defaults = {
     repaintIntervalRate: 60,
 
     /**
+     * Normally multiple calls to {@link Hypergrid#repaint grid.repaint()}, {@link Hypergrid#reindex grid.reindex()}, {@link Hypergrid#behaviorShapeChanged grid.behaviorShapeChanged()}, and/or {@link Hypergrid#behaviorStateChanged grid.behaviorStateChanged()} defer their actions until just before the next scheduled render. For debugging purposes, set `repaintImmediately` to truthy to carry out these actions immediately while leaving the paint loop running for when you resume execution. Alternatively, call {@link Canvas#stopPaintLoop grid.canvas.stopPaintLoop()}. Caveat: Both these modes are for debugging purposes only and may not render the grid perfectly for all interactions.
      * @default
      * @type {boolean}
      * @memberOf module:defaults

--- a/src/lib/Canvas.js
+++ b/src/lib/Canvas.js
@@ -181,7 +181,7 @@ Canvas.prototype = {
 
     beginPainting: function() {
         var self = this;
-        this.dirty = true;
+        this.requestRepaint();
         this.tickPainter = function(now) {
             self.tickPaint(now);
         };
@@ -525,8 +525,16 @@ Canvas.prototype = {
         });
     },
 
-    repaint: function() {
+    paintLoopRunning: function() {
+        return !!paintRequest;
+    },
+
+    requestRepaint: function() {
         this.dirty = true;
+    },
+
+    repaint: function() {
+        this.requestRepaint();
         if (!paintRequest || this.component.properties.repaintIntervalRate === 0) {
             this.paintNow();
         }

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -840,13 +840,15 @@ var Renderer = Base.extend('Renderer', {
      * @param {CanvasRenderingContext2D} gc
      */
     paintGridlines: function(gc) {
-        var visibleColumns = this.visibleColumns, C = visibleColumns.length, c, vc,
-            visibleRows = this.visibleRows, R = visibleRows.length, r, vr;
+        var visibleColumns = this.visibleColumns, C = visibleColumns.length,
+            visibleRows = this.visibleRows, R = visibleRows.length;
 
         if (C && R) {
             var gridProps = this.properties,
-                viewWidth = visibleColumns[C - 1].right,
-                viewHeight = visibleRows[R - 1].bottom,
+                C1 = C - 1,
+                R1 = R - 1,
+                viewWidth = visibleColumns[C1].right,
+                viewHeight = visibleRows[R1].bottom,
                 gridLinesVWidth = gridProps.gridLinesVWidth,
                 gridLinesHWidth = gridProps.gridLinesHWidth,
                 gridLinesVColor = gridProps.gridLinesVColor,
@@ -856,32 +858,29 @@ var Renderer = Base.extend('Renderer', {
             if (gridProps.gridLinesV) {
                 gc.cache.fillStyle = gridLinesVColor;
 
-                for (
-                    c = -1, vc = visibleColumns[c - 1]; // initial c = -2 is the row number column
-                    c < C;
-                    vc = visibleColumns[c++]
-                ) {
-                    if (vc) { // row number column and/or tree column may not be defined
+                visibleColumns.forEachWithNeg(function(vc, c) {
+                    if (
+                        vc && // tree column may not be defined
+                        c < C1 // don't draw rule after last column
+                    ) {
                         var x = vc.right,
                             top = vc.top || 0, // vc.top and vc.bottom accommodate grouped headers plug-in
                             height = (vc.bottom || viewHeight) - top;
                         if (borderBox) { x -= gridLinesVWidth; }
                         gc.fillRect(x, top, gridLinesVWidth, height);
                     }
-                }
+                });
             }
 
             if (gridProps.gridLinesH) {
                 gc.cache.fillStyle = gridLinesHColor;
-                for (
-                    r = 1, vr = visibleRows[r - 1]; // initial r = 0 is the top row
-                    r < R;
-                    vr = visibleRows[r++]
-                ) {
-                    var y = vr.bottom;
-                    if (borderBox) { y -= gridLinesHWidth; }
-                    gc.fillRect(0, y, viewWidth, gridLinesHWidth);
-                }
+                visibleRows.forEach(function(vr, r) {
+                    if (r < R1) { // don't draw rule below last row
+                        var y = vr.bottom;
+                        if (borderBox) { y -= gridLinesHWidth; }
+                        gc.fillRect(0, y, viewWidth, gridLinesHWidth);
+                    }
+                });
             }
 
             // draw fixed rule lines over grid rule lines
@@ -1254,7 +1253,7 @@ function computeCellsBounds() {
     this.scrollHeight = 0;
 
     this.visibleColumns.length = 0;
-    this.visibleColumns.gap = undefined;
+    this.visibleColumns.gap = this.visibleColumns[-1] = this.visibleColumns[-2] = undefined;
 
     this.visibleRows.length = 0;
     this.visibleRows.gap = undefined;

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -856,7 +856,8 @@ var Renderer = Base.extend('Renderer', {
 
             if (gridProps.gridLinesV && (gridProps.gridLinesColumnHeader || gridProps.gridLinesUserDataArea)) {
                 var gridLinesVWidth = gridProps.gridLinesVWidth,
-                    top = gridProps.gridLinesColumnHeader ? 0 : visibleRows[this.grid.getHeaderRowCount()].top,
+                    userDataAreaTop = visibleRows[this.grid.getHeaderRowCount()].top,
+                    top = gridProps.gridLinesColumnHeader ? 0 : userDataAreaTop,
                     bottom = gridProps.gridLinesUserDataArea ? viewHeight : visibleRows[this.grid.getHeaderRowCount() - 1].bottom;
 
                 gc.cache.fillStyle = gridLinesVColor;
@@ -868,9 +869,13 @@ var Renderer = Base.extend('Renderer', {
                     ) {
                         var x = vc.right,
                             lineTop = Math.max(top, vc.top || 0), // vc.top may be set by grouped headers plug-in
-                            height = bottom - lineTop;
+                            height = Math.min(bottom, vc.bottom || Infinity) - lineTop;
                         if (borderBox) { x -= gridLinesVWidth; }
                         gc.fillRect(x, lineTop, gridLinesVWidth, height);
+
+                        if (gridProps.gridLinesUserDataArea && vc.bottom < userDataAreaTop) {
+                            gc.fillRect(x, userDataAreaTop, gridLinesVWidth, bottom - userDataAreaTop);
+                        }
                     }
                 });
             }

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -862,9 +862,11 @@ var Renderer = Base.extend('Renderer', {
                     vc = visibleColumns[c++]
                 ) {
                     if (vc) { // row number column and/or tree column may not be defined
-                        var x = vc.right;
+                        var x = vc.right,
+                            top = vc.top || 0, // vc.top and vc.bottom accommodate grouped headers plug-in
+                            height = (vc.bottom || viewHeight) - top;
                         if (borderBox) { x -= gridLinesVWidth; }
-                        gc.fillRect(x, 0, gridLinesVWidth, viewHeight);
+                        gc.fillRect(x, top, gridLinesVWidth, height);
                     }
                 }
             }

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -847,15 +847,18 @@ var Renderer = Base.extend('Renderer', {
             var gridProps = this.properties,
                 C1 = C - 1,
                 R1 = R - 1,
+                rowHeader,
                 viewWidth = visibleColumns[C1].right,
                 viewHeight = visibleRows[R1].bottom,
-                gridLinesVWidth = gridProps.gridLinesVWidth,
-                gridLinesHWidth = gridProps.gridLinesHWidth,
                 gridLinesVColor = gridProps.gridLinesVColor,
                 gridLinesHColor = gridProps.gridLinesHColor,
                 borderBox = gridProps.boxSizing === 'border-box';
 
-            if (gridProps.gridLinesV) {
+            if (gridProps.gridLinesV && (gridProps.gridLinesColumnHeader || gridProps.gridLinesUserDataArea)) {
+                var gridLinesVWidth = gridProps.gridLinesVWidth,
+                    top = gridProps.gridLinesColumnHeader ? 0 : visibleRows[this.grid.getHeaderRowCount()].top,
+                    bottom = gridProps.gridLinesUserDataArea ? viewHeight : visibleRows[this.grid.getHeaderRowCount() - 1].bottom;
+
                 gc.cache.fillStyle = gridLinesVColor;
 
                 visibleColumns.forEachWithNeg(function(vc, c) {
@@ -864,21 +867,31 @@ var Renderer = Base.extend('Renderer', {
                         c < C1 // don't draw rule after last column
                     ) {
                         var x = vc.right,
-                            top = vc.top || 0, // vc.top and vc.bottom accommodate grouped headers plug-in
-                            height = (vc.bottom || viewHeight) - top;
+                            lineTop = Math.max(top, vc.top || 0), // vc.top may be set by grouped headers plug-in
+                            height = bottom - lineTop;
                         if (borderBox) { x -= gridLinesVWidth; }
-                        gc.fillRect(x, top, gridLinesVWidth, height);
+                        gc.fillRect(x, lineTop, gridLinesVWidth, height);
                     }
                 });
             }
 
-            if (gridProps.gridLinesH) {
+            if (
+                gridProps.gridLinesH && (
+                    gridProps.gridLinesUserDataArea ||
+                    (rowHeader = gridProps.gridLinesRowHeader && (visibleColumns[-1] || visibleColumns[-2]))
+                )
+            ) {
+                var gridLinesHWidth = gridProps.gridLinesHWidth,
+                    left = gridProps.gridLinesRowHeader ? 0 : visibleColumns[0].left,
+                    right = gridProps.gridLinesUserDataArea ? viewWidth : rowHeader.right;
+
                 gc.cache.fillStyle = gridLinesHColor;
+
                 visibleRows.forEach(function(vr, r) {
                     if (r < R1) { // don't draw rule below last row
                         var y = vr.bottom;
                         if (borderBox) { y -= gridLinesHWidth; }
-                        gc.fillRect(0, y, viewWidth, gridLinesHWidth);
+                        gc.fillRect(left, y, right - left, gridLinesHWidth);
                     }
                 });
             }


### PR DESCRIPTION
> NOTE: There will be no 2.1.9 release.

### New features
* Added new boolean grid props to more finely control where grid lines are rendered (all `true` by default):
   * `gridLinesColumnHeader`
   * `gridLinesRowHeader`
   * `gridLinesUserDataArea`
* Respect new `top` property of `grid.renderer.visibleColumns` elements _when defined._ (Set by grouped-headers plug-in to adjust lines so they're not drawn over group labels).
* Respect new `bottom` property of `grid.renderer.visibleColumns` elements _when defined_ (Set by grouped-headers plug-in to prevent lines from being drawn between column headers). When `bottom` is in the header _and_ `gridLinesUserDataArea` is truthy,  another line is drawn for the user data area.

### Bug fixes
* When the paint loop is not running (rarely used debug feature; not issues when paint loop is running normally):
   * `behaviorShapeChanged` and `behaviorStateChanged` were causing recursion
   * `reindex`, `behaviorShapeChanged`, `behaviorStateChanged` were not being called
* Remove defunct row and tree column elements when clearing `grid.renderer.visibleColumns` array

