### PR TITLE
Hypergrid v2.1.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ It also highlights a DOM-based custom external editor triggered via hypergrid ev
 * [Roadmap](#roadmap)
 * [Contributing](#contributors)
 
-### Current Release (2.1.9 - 1 May 2018)
+### Current Release (2.1.11 - 24 May 2018)
 
-**Hypergrid 2.1.9** includes bug fixes.
+**Hypergrid 2.1.11** includes bug fixes.
 
 _For a complete list of changes, see the [release notes](https://github.com/fin-hypergrid/core/releases)._
 
@@ -52,13 +52,13 @@ Find more information on our [testing page](TESTING.md)
 
 Primarily our tutorials will be on the [wiki](https://github.com/fin-hypergrid/core/wiki).
 
-We also maintain versioned [online API documentation](https://fin-hypergrid.github.io/core/2.1.9/doc/Hypergrid.html) for all public objects and modules. This documentation is necessarily an on-going work-in-progress.
+We also maintain versioned [online API documentation](https://fin-hypergrid.github.io/core/2.1.11/doc/Hypergrid.html) for all public objects and modules. This documentation is necessarily an on-going work-in-progress.
 
 (Cell editor information can be found [here](https://github.com/fin-hypergrid/core/wiki/Cell-Editors).)
 
 (Cell Rendering information can be found [here](https://github.com/fin-hypergrid/core/wiki/Cell-Renderers).)
 
-Hypergrid global configurations can be found [here](https://fin-hypergrid.github.io/core/2.1.9/doc/module-defaults.html).
+Hypergrid global configurations can be found [here](https://fin-hypergrid.github.io/core/2.1.11/doc/module-defaults.html).
 
 ### Roadmap
 

--- a/demo/formatter-workbench/index.css
+++ b/demo/formatter-workbench/index.css
@@ -1,0 +1,51 @@
+body {
+    font: 9pt sans-serif;
+    margin: 8px;
+}
+table {
+    border-spacing: 12px 6px;
+}
+textarea {
+    font: 8pt monospace;
+    background-color: ivory;
+    border-radius: 5px;
+    height: 100%;
+    width: 100%;
+    transition: background-color 1s;
+}
+textarea.zowie {
+    background-color: yellow;
+    transition: none;
+}
+label {
+    white-space: nowrap;
+    font: normal 9pt sans-serif;
+}
+select, input {
+    /*margin-right: .5em;*/
+    outline: 0;
+}
+input[type=button] {
+    background-color: grey;
+    color: white;
+    border: 1px dotted transparent;
+}
+input[type=button].locals {
+    cursor: help;
+    float: left;
+    margin-left: 3em;
+    border-radius: 4px;
+}
+input[type=button].api {
+    font: 14px monospace;
+    border-radius: 7px;
+    padding: 3px 9px;
+}
+input[type=button]:hover {
+    background-color: #555;
+}
+input[type=button]:active {
+    color: #555;
+    background-color: white;
+    border-color: grey;
+}

--- a/demo/formatter-workbench/index.html
+++ b/demo/formatter-workbench/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" >
+    <title>Hypergrid Cell Formatter &amp; Editor Workbench</title>
+    <link rel="stylesheet" href="index.css">
+</head>
+<body>
+
+<h1 style="margin:.5em; color:lightgrey">
+    Hypergrid Cell Formatter &amp; Editor Workbench
+    <div style="float:right; font: 9pt sans-serif">
+        <a href="instructions.html" target="instructions">Instructions…</a>
+    </div>
+</h1>
+
+<table style="width:100%"><tr>
+    <td>
+        <input type="button" class="api" value="grid.setData(…)" onclick="callApi('setData', 'data', true)">
+    </td>
+    <td>
+        <input type="button" class="api" value="grid.addState(…)" onclick="callApi('addState', 'state', true)">
+    </td>
+</tr><tr>
+    <td style="width:50%; height:300px">
+        <textarea id="data"></textarea>
+    </td>
+    <td style="width:50%; height:300px">
+        <textarea id="state"></textarea>
+    </td>
+</tr><tr>
+    <td style="text-align:right; white-space: nowrap">
+        Load localizer:
+        <select id="localizer-dropdown"></select>
+        <input type="button" class="api" value="grid.localization.add(…)" style="float:left">
+        <input type="button" value="Locals" class="locals">
+    </td>
+    <td style="text-align:right; white-space: nowrap">
+        Load cell editor:
+        <select id="editor-dropdown"></select>
+        <input type="button" class="api" value="grid.cellEditors.add(…)" style="float:left">
+        <input type="button" value="Locals" class="locals">
+    </td>
+</tr><tr>
+    <td style="height:300px">
+        <textarea id="localizer-script"></textarea>
+    </td>
+    <td style="height:300px">
+        <textarea id="editor-script"></textarea>
+    </td>
+</tr></table>
+
+
+<script src="../build/fin-hypergrid.js"></script>
+
+<script>var exports = {}, module = {exports};</script>
+<script src="scripts.js"></script>
+<script>var scripts = module.exports; delete window.exports; delete window.module;</script>
+
+<script src="index.js"></script>
+
+</body>
+</html>

--- a/demo/formatter-workbench/index.js
+++ b/demo/formatter-workbench/index.js
@@ -1,0 +1,213 @@
+'use strict';
+
+var grid = new fin.Hypergrid({ boundingRect: { height: '141px' } }); // 5 * 28 + 2 - 1
+
+grid.properties.defaultRowHeight = 26;
+grid.properties.foregroundSelectionFont = 'bold ' + (grid.properties.font = '14pt sans-serif');
+
+putJSON('data', [
+    { symbol: 'APPL', name: 'Apple Inc.', prevclose: 93.13 },
+    { symbol: 'MSFT', name: 'Microsoft Corporation', prevclose: 51.91 },
+    { symbol: 'TSLA', name: 'Tesla Motors Inc.', prevclose: 196.40 },
+    { symbol: 'IBM', name: 'International Business Machines Corp', prevclose: 155.35 }
+]);
+
+callApi('setData', 'data');
+
+putJSON('state', {
+    editable: true,
+    editor: 'textfield',
+    columns: {
+        prevclose: {
+            halign: 'right',
+            format: 'trend'
+        }
+    }
+});
+
+grid.addProperties({
+    showRowNumbers: false
+});
+
+callApi('addState', 'state');
+
+grid.addEventListener('fin-after-cell-edit', function(e) {
+    putJSON('data', grid.behavior.getData());
+});
+
+initLocalsButton('editor', Object.keys(grid.cellEditors.items).concat(['module', 'CellEditor']));
+initLocalsButton('localizer', 'module');
+
+var saveFuncs = {
+    editor: saveCellEditor,
+    localizer: saveLocalizer
+};
+
+Object.keys(scripts).forEach(function(key) {
+    initScripts(key);
+});
+
+function initLocalsButton(type, locals) {
+    var el = document.getElementById(type + '-dropdown').nextElementSibling.nextElementSibling;
+    var locals = [].concat(locals).sort();
+    el.title = locals.join('\n');
+    el.onclick = function() { alert('Local variables: ' + locals.join(', ')); };
+}
+
+function initScripts(type) {
+    var scriptList = scripts[type],
+        dropdownEl = document.getElementById(type + '-dropdown'),
+        scriptEl = document.getElementById(type + '-script'),
+        addButtonEl = dropdownEl.nextElementSibling,
+        save = saveFuncs[type];
+
+    scriptList.map(extractName).sort().forEach(function(key) {
+        dropdownEl.add(new Option(key));
+        if (key !== '(New)') {
+            save(findScript(scriptList, key));
+        }
+    });
+
+    dropdownEl.onchange = function() {
+        scriptEl.value = findScript(scriptList, this.value);
+    };
+
+    dropdownEl.onchange();
+
+    addButtonEl.onclick = function() {
+        save(scriptEl.value, dropdownEl);
+    }
+}
+
+function findScript(scriptList, name) {
+    return scriptList.find(isScriptByName.bind(null, name));
+}
+
+function saveScript(scriptList, name, script) {
+    var index = scriptList.findIndex(isScriptByName.bind(null, name));
+    if (index >= 0) {
+        scriptList[index] = script;
+    } else {
+        scriptList.push(script);
+    }
+}
+
+function isScriptByName(name, script) {
+    return extractName(script) === name;
+}
+
+function extractName(script) {
+    var match = script.match(/\.extend\('([^']+)'|\.extend\("([^"]+)"|\bname:\s*'([^']+)'|\bname:\s*"([^"]+)"/);
+    return match[1] || match[2] || match[3] || match[4];
+}
+
+function putJSON(key, json) {
+    document.getElementById(key).value = JSON.stringify(json, undefined, 2)
+        .replace(/(  +)"([a-zA-Z$_]+)"(: )/g, '$1$2$3'); // un-quote keys
+}
+
+function callApi(methodName, id, zow) {
+    var value;
+
+    // L-value must be inside eval because R-value beginning with '{' is eval'd as BEGIN block
+    // used eval because JSON.parse rejects unquoted keys
+    eval('value =' + document.getElementById(id).value);
+    grid[methodName].call(grid, value);
+
+    if (zow) {
+        zowie(document.getElementById(id));
+    }
+}
+
+function saveCellEditor(script, select) {
+    var cellEditors = grid.cellEditors;
+    var editorNames = Object.keys(cellEditors.items);
+    var editors = editorNames.map(function(name) { return cellEditors.items[name]; });
+    var module = {};
+    var formalArgs = [null, 'module', 'CellEditor']
+        .concat(editorNames) // additional params
+        .concat(script); // function body
+    var actualArgs = [module, cellEditors.BaseClass].concat(editors);
+
+    try {
+        var closure = new (Function.prototype.bind.apply(Function, formalArgs)); // calls Function constructor using .apply
+        closure.apply(null, actualArgs);
+        var Editor = module.exports;
+        var name = Editor.prototype.$$CLASS_NAME;
+        if (!(Editor.prototype instanceof cellEditors.BaseClass)) {
+            throw 'Cannot save cell editor "' + name + '" because it is not a subclass of CellEditor (accessible as grid.cellEditors.BaseClass).';
+        }
+        if (!name || name === 'new') {
+            throw 'Cannot save cell editor. A `name` property with a value other than "new" is required.';
+        }
+    } catch (err) {
+        console.error(err);
+        alert(err + '\n\nAvailable locals: ' + formalArgs.slice(1, formalArgs.length - 1).join(', ') +
+            '\n\nNOTE: Cell editors that extend directly from CellEditor must define a `template` property.');
+        return;
+    }
+
+    cellEditors.add(Editor);
+
+    saveScript(scripts.editor, name, script);
+
+    addOptionInAlphaOrder(select, name);
+
+    if (select) {
+        zowie(document.getElementById(select.id.replace('-dropdown', '-script')));
+    }
+}
+
+function saveLocalizer(script, select) {
+    var module = {};
+
+    try {
+        var closure = new Function('module', script);
+        closure(module);
+        var localizer = module.exports;
+        var name = localizer.name;
+        if (!name || name === '(New)') {
+            throw 'Cannot save localizer. A `name` property with a value other than "(New)" is required.';
+        }
+        grid.localization.add(localizer);
+    } catch (err) {
+        console.error(err);
+        alert(err + '\n\nAvailable locals:\n\tmodule');
+        return;
+    }
+
+    saveScript(scripts.localizer, name, script);
+
+    addOptionInAlphaOrder(select, name);
+
+    if (select) {
+        zowie(document.getElementById(select.id.replace('-dropdown', '-script')));
+    }
+}
+
+function addOptionInAlphaOrder(el, text, value) {
+    if (!el) {
+        return;
+    }
+
+    var optionEls = Array.prototype.slice.call(el.options);
+
+    if (optionEls.find(function(optionEl) { return optionEl.textContent === text; })) {
+        return; // already in dropdown
+    }
+
+    var firstOptionGreaterThan = optionEls.find(function(optionEl) {
+        return optionEl.textContent > text;
+    });
+
+    el.value = name;
+    if (el.selectedIndex === -1) {
+        el.add(new Option(text, value), firstOptionGreaterThan);
+        el.selectedIndex = el.options.length - 1;
+    }
+}
+
+function zowie(el) {
+    el.className = 'zowie';
+    setTimeout(function() { el.className = ''; }, 400);
+}

--- a/demo/formatter-workbench/instructions.html
+++ b/demo/formatter-workbench/instructions.html
@@ -1,0 +1,383 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {
+            font: 10pt sans-serif;
+            margin: 8px;
+            column-gap: 2em;
+        }
+        pre {
+            font: 8pt monospace;
+            background-color: #eee;
+            border: 1px solid #aaa;
+            padding: 0.4em;
+            white-space: pre-wrap;
+        }
+        span.button {
+            background-color: #eee;
+            border: 1px solid black;
+            border-radius: 3px;
+            padding: 1px 3px;
+            font-size: 7pt;
+            font-weight: bold;
+        }
+        a.code, code {
+            font-family: monospace;
+            font-weight: bold;
+            color: #444;
+            background-color: #ddd;
+            padding: 0 4px;
+            border-radius: 3px;
+        }
+        li {
+            margin: .3em 0 .3em -1em;
+        }
+        h3 {
+            background-color: #666;
+            color: white;
+            margin-left: -4px;
+            padding: 5px 8px;
+            border-radius: 6px;
+            text-align: center;
+            font: 14pt cursive;
+            letter-spacing: 1px;
+        }
+        h4 {
+            color: #666;
+            border-top: 1px dashed #aaa;
+            padding-top: 5px;
+            margin-bottom: .65em;
+        }
+        h5 {
+            color: #666;
+            font-style: italic;
+            font-size: 9pt;
+            margin-top: 1em;
+            margin-bottom: .5em;
+        }
+        div.note {
+            text-align: center;
+            margin: 1em 15%;
+            padding: .75em;
+            background-color: ivory;
+            border: 3px orange double;
+        }
+    </style>
+</head>
+<body>
+
+<h2 style="margin-top:0">
+    Instructions
+    <div style="float:right; font-size: 10pt; font-weight: normal">
+        Columns:
+        <select style="outline:0">
+            <option>1</option>
+            <option>2</option>
+            <option>3</option>
+            <option>4</option>
+        </select>
+    </div>
+</h2>
+
+…for the Hypergrid Cell Formatter &amp; Editor Workbench
+
+<div class="note">
+    This document discusses the workbench user
+    interface and concludes with a <a href="#example">tutorial/example</a>.
+</div>
+
+<p>This “workbench” is for learning about Hypergrid cell formatting and editing using <em>localizers</em> and <em>cell editors</em>.
+You can also use it for actual development and testing of these objects, but be aware this app does not persist your work anywhere.
+Be carefore to cut &amp; paste anything you want to keep!</p>
+
+<div style="page-break-inside: avoid">
+    <h3>Data pane</h3>
+    A data pane is provided to adjust the data to suit the needs of your localizers and cell editors.
+    Bind the data to the grid by clicking <code class="button">grid.setData(…)</code> button.
+    The grid in turn is bound to the data window for any edits made to cells using cell editors.
+</div>
+
+<div style="page-break-inside: avoid">
+    <h3>State pane</h3>
+    This pane lets you add a set of properties declaratively to the grid.
+    Properties can also be set programmaticaly from the console with the various set property methods.
+</div>
+
+<div style="page-break-inside: avoid">
+    <h4>Example</h4>
+    <ol>
+        <li>Edit the state pane to make the <code>prevclose</code> column to use the <code>ft-in</code> (“foot-inch”) localizer.</li>
+        <li>Click the <code class="button">grid.addState(…)</code> button.</li>
+        <li>Notice how these values are now formatted as feet and inches.</li>
+        <li>Double click one of these formatted values in the grid. Cell editing is enabled because:
+            <ul>
+                <li>The cell’s <code>editable</code> property is truthy.</li>
+                <li>The cell’s <code>editor</code> property is defined and resolves to a registered cell editor.</li>
+                <li>The cell’s <code>ft-in</code> localizer has a <a href="https://fin-hypergrid.github.io/core/doc/localizerInterface.html#parse" class="code">parse</a> method. (You can see the localizer by selecting it from the dropdown in the Localizer pane.)</li>
+            </ul>
+        </li>
+        <li>Notice how editing in the grid is done in the format specified by the localizer (unlike the in the Data pane where these numbers are integers). The cell editor uses the localizer’s <a href="https://fin-hypergrid.github.io/core/doc/localizerInterface.html#parse" class="code">parse</a> function to turn the edited value back into an integer.</li>
+    </ol>
+</div>
+
+<div style="page-break-inside: avoid">
+<h3>Localizer pane</h3>
+Value formatting in Hypergrid is controlled by <em>localizers,</em> objects with the following shape:
+
+<pre>{
+  format: function(str), // required; returns value
+  parse: function(value), // required; returns string
+  invalid: function(value), // optional; helper function for `parse`
+  expectation: "optional error message describing expected syntax"
+}</pre>
+</div>
+
+Formatting grid cell values is purely a text string manipulation. Any other graphical effects are the purview of cell renderers (not covered here). Cell editors can include fancy controls for manipulating the string, but the result needs to be a formatted string (which will be parsed before storing the result in the data model).
+
+<div style="page-break-inside: avoid">
+    <h4><a href="https://fin-hypergrid.github.io/core/doc/localizerInterface.html#format" class="code">format</a></h4>
+    <em>Required.</em>
+    Formats raw data values for display in the grid.
+</div>
+
+<div style="page-break-inside: avoid">
+    <h4><a href="https://fin-hypergrid.github.io/core/doc/localizerInterface.html#parse" class="code">parse</a></h4>
+    <em>Required.</em>
+    Parses values in the displayed format, converting them back into raw data values. Used by cell editors to store results back to data model, or by search algorithms to compare a formatted value to other cells' raw values (without having to format every on of the other cells), <i>etc.</i>
+</div>
+
+<p></p>Although <a href="https://fin-hypergrid.github.io/core/doc/localizerInterface.html#parse" class="code">parse</a> is only called by Hypergrid when a formatted cell is edited, an implementation is currently required (by <code>add</code>). The reason for this is "completeness" — to be ready and available when your application inevitably needs to parse a value later on. The assumption is it’s easier to write a parser when you write the formatter than to have to go back later and rethink it. <em>That said, you can provide a no-op implementation to fake out <code>add</code> but you do so at your peril. (So long as the cells using this localizer are not editable you should be all right.)</em></li>
+
+<div style="page-break-inside: avoid">
+    <h4><a href="https://fin-hypergrid.github.io/core/doc/localizerInterface.html#invalid" class="code">invalid</a></h4>
+    <em>Optional.</em>
+    Validates the syntax.
+    Usually implemented with a <Code>RegExp</code>. For example (replace <code>regex</code> with an actual regex):
+    <pre>  invalid: function(str) { return !/^regex$/.test(); }</pre>
+    Should be implemented when <a href="https://fin-hypergrid.github.io/core/doc/localizerInterface.html#parse" class="code">parse</a> is not bulletproof (when it would jam unexpectedly on bad syntax). When implemented, <a href="https://fin-hypergrid.github.io/core/doc/localizerInterface.html#invalid" class="code">invalid</a> is called first; <a href="https://fin-hypergrid.github.io/core/doc/localizerInterface.html#parse" class="code">parse</a> is only called if the syntax is valid (<a href="https://fin-hypergrid.github.io/core/doc/localizerInterface.html#invalid" class="code">invalid</a> returns falsy; <i>i.e.,</i> “not invalid”).
+    </div>
+
+    <div style="page-break-inside: avoid">
+    <h4><a href="https://fin-hypergrid.github.io/core/doc/localizerInterface.html#expectation" class="code">expectation</a></h4>
+    <em>Optional.</em>
+    A friendly description of the expected syntax. Used for error feedback, but also helpful for self-documenting the localizer.
+</div>
+
+<div style="page-break-inside: avoid">
+    <h4>Define a new localizer and add it to the grid</h4>
+    <ol>
+        <li>Select <strong>(New)</strong> from the <em>Load localizer</em> drop-down.</li>
+        <li>Rename it with a unique name by editing the <a href="https://fin-hypergrid.github.io/core/doc/localizerInterface.html#name" class="code">name</a> field.</li>
+        <li>Add additional local variables by declaring them at the top, as needed.</li>
+        <li>Code your localizer referring to examples and the <a href="https://fin-hypergrid.github.io/core/doc/localizerInterface.html" target="localizer-docs">localizer interface</a> documentation.</li>
+        <li>Be sure to assign your localizer to <code>module.exports</code>.</li>
+        <li>Click the <span class="button">grid.localization.add(…)</span> button.</li>
+        <li><em>Optional:</em> Edit the localizer and click <span class="button">grid.localization.add(…)</span> to update it.</li>
+    </ol>
+</div>
+
+For example, here’s a localizer to show a “degrees” unit:
+<pre>grid.localization.add('deg', { format: function(s) { return s + '°' } }</pre>
+(Notice incidentally how <code>add</code> can optionally accept a name parameter for localizers that lack a <a href="https://fin-hypergrid.github.io/core/doc/localizerInterface.html#name" class="code">name</a> property.)
+
+<div style="page-break-inside: avoid">
+    <h4>Bind the localizer to a cell</h4>
+    Bind a localizer using the <a href="https://fin-hypergrid.github.io/core/doc/localizerInterface.html#format" class="code">format</a> property. As always, a property can be set for the entire grid, a specific column (or row), or a specific cell.
+    There are many ways to do this programmatically from the console with the various property setting methods.
+</div>
+
+<p>From this interface, edit the state and click the <span class="button">grid.addState(…)</span> button:</p>
+<ul>
+    <li>State object to set grid <a href="https://fin-hypergrid.github.io/core/doc/localizerInterface.html#format" class="code">format</a> property to <code>'deg'</code>: <pre>{ format: 'deg' }</pre></li>
+    <li>To set column property: <pre>{ columns: { data: { prevclose: { format: 'deg' } } } }</pre></li>
+    <li>To set row property: <pre>{ rows: { data: { 3: { format: 'deg' } } } }</pre></li>
+    <li>To set cell property: <pre>{ cells: { data: { 3: { prevclose: { format: 'deg' } } } } }</pre></li>
+    <li>The <code>editable: true</code> (grid) property in the default state shown above is included for clarity (<code>true</code> is the default)</li>
+</ul>
+
+<div style="page-break-inside: avoid">
+    <h4>Edit an existing localizer</h4>
+    <ul>
+        <li>Select a localizer to edit from the <em>Load localizer</em> drop-down.</li>
+        <li>Edit the localizer.</li>
+        <li>Click the <span class="button">grid.localization.add(…)</span> button to replace the existing cell editor with your changes.</li>
+    </ul>
+</div>
+
+<div style="page-break-inside: avoid">
+    <h4>Duplicate an existing localizer</h4>
+    <ul>
+        <li>Select a localizer to edit from the <em>Load localizer</em> drop-down.</li>
+        <li>Rename it with a new unique name by editing the <a href="https://fin-hypergrid.github.io/core/doc/localizerInterface.html#name" class="code">name</a> field.</li>
+        <li>Click the <span class="button">grid.localization.add(…)</span> button to save it under the new name.</li>
+    </ul>
+</div>
+
+<div style="page-break-inside: avoid">
+    <h3>Cell editor pane</h3>
+        This pane lets you create and edit cell editors. It comes with a sample cell editor called <code>Time</code> for editing values formatted with the <code>hh:mm</code> localizer.
+    <h4>Define a new cell editor in this workbench</h4>
+    Procedure is similar to that for localizer (see above) except:
+    <ul>
+        <li>Hover over (or click) <span class="button">Locals</span> button to see defined local variables.</li>
+        <li>Refer to the <a href="https://fin-hypergrid.github.io/core/doc/CellEditor.html" target="cell-editor-docs">API documentation</a>
+            and the code (<a href="https://github.com/fin-hypergrid/core/blob/master/src/cellEditors/CellEditor.js" target="cell-editor-code">CellEditor.js</a>).</li>
+        <li>Use the <span class="button">grid.cellEditors.add(…)</span> button (rather than <span class="button">grid.localization.add(…)</span>.</li>
+        <li>Be sure to define the <a href="https://fin-hypergrid.github.io/core/doc/localizerInterface.html#parse" class="code">parse</a> function, which is required for editing, as well as the <a href="https://fin-hypergrid.github.io/core/doc/localizerInterface.html#format" class="code">format</a> funciton.</li>
+    </ul>
+</div>
+
+<div style="page-break-inside: avoid">
+    <h4>Bind the cell editor to a cell</h4>
+    Procedure is similar to that for localizer (see above) except:
+    <ul>
+        <li>Use the <code>editor</code> binding (rather than <a href="https://fin-hypergrid.github.io/core/doc/localizerInterface.html#format" class="code">format</a>).</li>
+    </ul>
+</div>
+
+<div style="page-break-inside: avoid">
+    <h4>Edit an existing cell editor</h4>
+    Procedure is similar to that for localizer (see above).
+</div>
+
+<div style="page-break-inside: avoid">
+    <h4>Duplicate an existing cell editor</h4>
+    Procedure is similar to that for localizer (see above).
+</div>
+
+<div style="page-break-inside: avoid">
+    <h3>Grid</h3>
+    The live Hypergrid appears below the other panes.
+</div>
+
+<div style="page-break-inside: avoid">
+    <h3 id="example">Tutorial / Example</h3>
+    The <code>prevclose</code> column is set to use this localizer (see the State pane), whose <a href="https://fin-hypergrid.github.io/core/doc/localizerInterface.html#format" class="code">format</a> function formats positive numbers with an up-arrow (⬆) and negative numbers with a down-arrow (⬇). The data for this column are all initially positive (see Data pane), so all values are formatted with up-arrows (see Grid).
+    </div>
+
+    <div style="page-break-inside: avoid">
+    <h4>Edit the cell value in the data pane</h4>
+    <ol>
+        <li>In the data pane, change a couple of the <code>prevclose</code> values to negative numbers.</li>
+        <li>Click the <code class="button">grid.setData(…)</code> button.</li>
+        <li>Notice how these values are now formatted with down-arrows in the grid.</li>
+    </ol>
+</div>
+
+<div style="page-break-inside: avoid">
+    <h4>Edit the cell in the grid</h4>
+    <ol>
+        <li>Double click one of these formatted values in the grid to edit it using the <a href="https://github.com/fin-hypergrid/core/blob/master/src/cellEditors/Textfield.js" class="code">Textfield</a> cell editor.</li>
+        <li>Cell editors append additional elements to the DOM, positioned precisely to the cell bounds.</li>
+        <li>Edit the cell. This editor is for straight-forward text editing; it has no special controls for handling the arrows which are arrows are not available on the keyboard. You could cut &amp; paste a down-arrow from another cell; or as a special accommodation to this problem the <code>trend</code> localizer’s <a href="https://fin-hypergrid.github.io/core/doc/localizerInterface.html#parse" class="code">parse</a> function also accepts a prefixed negative sign.</li>
+        <li>Press the <strong>enter</strong> key.</li>
+        <li>The <a href="https://fin-hypergrid.github.io/core/doc/localizerInterface.html#parse" class="code">parse</a> function converts the input to a value.</li>
+        <li>Editor is closed.</li>
+        <li>Grid is updated with the new value.</li>
+        <li>Data pane is also updated with the new value.</li>
+    </ol>
+</div>
+
+<div style="page-break-inside: avoid">
+    <h4>Edit the localizer</h4>
+    Let’s improve the localizer.
+    <h5>Throw error on parser failer</h5>
+    The <code>trend</code> localizer’s <a href="https://fin-hypergrid.github.io/core/doc/localizerInterface.html#parse" class="code">parse</a> function has a problem. It doesn't properly throw an error on failure:
+    <ol>
+        <li>Double-click another cell to edit it, seting the contents to some invalid value (such as “xyz” which is not a number).</li>
+        <li>Press the <strong>enter</strong> key.</li>
+        <li>The parser cannot convert the value.</li>
+        <li>Editor is closed.</li>
+        <li>Grid is updated with null.</li>
+        <li>Data pane is also updated with null.</li>
+    </ol>
+</div>
+
+<div style="page-break-inside: avoid">
+    The solution is to have the <a href="https://fin-hypergrid.github.io/core/doc/localizerInterface.html#parse" class="code">parse</a> function throw an error when it cannot convert the value. If the native <code>window.parseFloat</code> function threw an error on failure we'd be there already. Instead, it returns <code>NaN</code> (“<u>n</u>ot <u>a</u> <u>n</u>umber”) on failure. Let’s catch the <code>NaN</code> and throw an actual error:
+    <ol>
+        <li>In the Localizer pane, select the <code>trend</code> localizer.</li>
+        <li>Uncomment the <code><i>if</i></code> statement with the <code><i>throw</i></code> statement within it.</li>
+        <li>Edit another cell, again setting the contents to some invalid value.</li>
+        <li>Press the <strong>enter</strong> key.</li>
+        <li>The parser cannot convert the value.</li>
+        <li>Negative feedback animation plays.</li>
+        <li>Every third failure (press <strong>enter</strong> again) is accompanied by an <code>alert</code> with additional information (the error’s message is shown in the alert).</li>
+    </ol>
+</div>
+
+<div style="page-break-inside: avoid">
+    <h5>Check for valid syntax</h5>
+    The <a href="https://fin-hypergrid.github.io/core/doc/localizerInterface.html#parse" class="code">parse</a> function as implemented correctly parses expected input. However, it’s not a fully realized finite-state machine; it doesn't parse the input as a grammar and therefore doesn't catch invalid syntax. Specifically, this parser ignores extraneous characters between a valid floating point number and the end of string, which conveniently ignores the arrows, but also anything else. There are two choices for addressing this:
+    <ol>
+        <li>Make the parser "bulletproof" by implementing an FSM (from scratch or via a <code>RegExp</code>).</li>
+        <li>Implement an <a href="https://fin-hypergrid.github.io/core/doc/localizerInterface.html#invalid" class="code">invalid</a> function to do a syntax pre-scan, which allows a (simpler) parser to assume the syntax is valid.</li>
+    </ol>
+</div>
+
+<div style="page-break-inside: avoid">
+    <h5>Display syntax hint</h5>
+    If you implement the <a href="https://fin-hypergrid.github.io/core/doc/localizerInterface.html#expectation" class="code">expectation</a> string property, that string (a friendly description of the syntax) will be included in the error alert mentioned above. If <a href="https://fin-hypergrid.github.io/core/doc/localizerInterface.html#parse" class="code">parse</a> is called and it throws an error with a defined <code>message</code> property, that message will also be included (prepended to the expectation message).
+</div>
+
+<div style="page-break-inside: avoid">
+    <h4>Cell editors</h4>
+    We haven't discussed cell editors so far. Often, the <a href="https://github.com/fin-hypergrid/core/blob/master/src/cellEditors/Textfield.js" class="code">Textfield</a> cell renderer + a localizer with well-defined <a href="https://fin-hypergrid.github.io/core/doc/localizerInterface.html#format" class="code">format</a> and <a href="https://fin-hypergrid.github.io/core/doc/localizerInterface.html#parse" class="code">parse</a> methods is all you need. A custom cell renderer is needed when what you’re editing cannot be easily represented or conveniently edited as text, or if you want to code special event handlers (such as ignoring illegal chars).
+</div>
+
+<div style="page-break-inside: avoid">
+    <h5>Bind to a cell editor</h5>
+    Cell editors depend on localizers and always have a default localizer that is used when the cell does not define a custom localizer (in its <code>format</code> property). Custom cell editors generally work hand-in-hand with a custom localizer. Let’s add a simple editor to the <code>prevclose</code> column. The column already specifies a custom localizer, <code>trend</code>. We're going to bind a custom cell editor to this column, also called <code>Trend</code>.
+</div>
+
+<blockquote style="font-size:smaller"><i>Note:</i> The <code>get</code> methods, such as <code>grid.localization.get(localizerName)</code> and <code>grid.cellEditors.get(cellEditorName)</code> treat their parameter as case-insensitive. Localizer and cell editor names must be unique but exist in different name spaces which is why these two names don't clash (not case differences.) The only reason cell editors start with a capital letter is a nod to the fact that they’re object constructors (or "classes" which by long-standing convention are always capitalized).</blockquote>
+
+<ol>
+    <li>In the State pane, add <code>editor: "Trend"</code> to the <code>prevclose</code> column.</li>
+    <li>Click the <span class="button">grid.addState(…)</span> button.</li>
+    <li>Double-click a cell in the <code>prevclose</code> column.</li>
+    <li>Click the arrow and notice how it flips.</li>
+    <li>Press the <span class="button">enter</span> key to save the change or <span class="button">esc</span> key to cancel it.</li>
+</ol>
+
+This cell editor makes toggling the arrow a simple matter of clicking on it. This usually would not be worth writing a cell editor for — except that in this case, the Unicode arrows are not on the keyboard so they're impossible to type.
+
+<div style="page-break-inside: avoid">
+    <h5>Edit the cell editor</h5>
+    Take a look at the <code>Trend</code> cell editor:
+    <ol>
+        <li>In the Cell Editor pane, select "Trend" from the drop-down.</li>
+        <li>Uncomment the <code>keypress</code> event handler.</li>
+        <li>Click the <span class="button">grid.cellEditors.add(…)</span> button.</li>
+        <li>Double-click a cell in the <code>prevclose</code> column.</li>
+        <li>Type <span class="button">&plus;</span> or <span class="button">&minus;</span> and notice how the arrow flips.</li>
+    </ol>
+</div>
+
+This <code>keypress</code> handler does two things:
+<ol>
+    <li>The <code>case '+'</code> and <code>case '-'</code> cases let the user "type" in the arrows at any time during editing by pressing the <span class="button">&plus;</span> or <span class="button">&minus;</span> keys for up-arrow or down-arrow, respectively.</li>
+    <li>The <code>default</code> case discards unexpected key presses, triggering an error feedback animation.</li>
+</ol>
+
+<div style="page-break-inside: avoid">
+    <h5>Regarding <code>this.super</code></h5>
+    Calling the superclasses implementation from <code>setEditorValue</code>, <code>setEditorValue</code>, and  <code>setEditorValue</code>, while not a requirement, is a common pattern and is recommended.
+</div>
+
+<div style="page-break-inside: avoid">
+    <h3>Debugging cell editors</h3>
+    Because the workbench's cell editors are dynamically added and don't exist as code files, debugging is challenging. To see your cell editor's code page, make sure you have an <code>initialize</code> method (even if it’s empty). From the browser console, load up <code>src/cellEditors/CellEditor.js</code>. Place a breakpoint on the last line of the <code>initialize</code> method. From there 1 &times; "step-over" &plus; 3 &times; "step-into" and you should find yourself in the subclass’s <code>initialize</code> method. (To get to a sub-subclass: .1 &times; "step-out" &plus; 3 &times; "step-into") Now that the debugger is displaying your cell editor, you can set breakpoints in your other methods.
+</div>
+
+<script>
+    var c = document.querySelector('select');
+    c.value = Math.floor(window.innerWidth / 500);
+    c.onchange = function() {
+        document.body.style.columns = this.selectedIndex + 1;
+    };
+    c.onchange();
+</script>
+</body>
+</html>

--- a/demo/formatter-workbench/scripts.js
+++ b/demo/formatter-workbench/scripts.js
@@ -1,0 +1,182 @@
+'use strict';
+
+exports.editor = [
+
+`module.exports = Textfield.extend('(New)', {
+
+});`,
+
+`module.exports = Textfield.extend('Trend', {
+    template: [
+      '<div class="hypergrid-textfield" style="text-align:right; white-space:nowrap;">',
+      '  <input type="text" lang="{{locale}}" style="background-color:transparent; width:77%; text-align:right; border:0; padding:0; outline:0; font:inherit; margin-right: -1px;' +
+      '{{style}}"><span>⬆</span>',
+      '</div>'
+    ].join('\\n'),
+
+    initialize: function() {
+      this.input = this.el.querySelector('input');
+      this.trend = this.el.querySelector('span');
+
+      // Flip AM/PM on any click
+      this.trend.onclick = function() {
+        this.trend.textContent = this.trend.textContent === '⬆' ? '⬇' : '⬆';
+        this.input.focus(); // return focus to text field
+      }.bind(this);
+
+/*
+      // Flip AM/PM on 'am' or 'pm' keypresses
+      this.input.onkeypress = function(e) {
+        switch (e.key) {
+          case '+': this.trend.textContent = '⬆'; e.preventDefault(); break;
+          case '-': this.trend.textContent = '⬇'; e.preventDefault(); break;
+          default:
+            // only allow digits, decimal point, and specials (ENTER, TAB, ESC)
+            if ('0123456789.'.indexOf(e.key) < 0 && !this.specialKeyups[e.keyCode]) {
+              this.errorEffectBegin(); // feedback for unexpected key press
+              e.preventDefault();
+            }
+        }
+      }.bind(this);
+*/
+    },
+
+    setEditorValue: function(value) {
+      this.super.setEditorValue.call(this, value);
+      this.trend.textContent = value < 0 ? '⬇' : '⬆';
+      this.input.value = Math.abs(value).toFixed(2);
+    },
+
+    getEditorValue: function(value) {
+      return this.super.getEditorValue.call(this, value + this.trend.textContent);
+    },
+    
+    validateEditorValue: function(value) {
+      return this.super.validateEditorValue.call(this, value + this.trend.textContent);
+    }
+
+});`
+
+];
+
+exports.localizer = [
+
+`module.exports = {
+  name: '(New)',
+  format: function(value) {
+    var str;
+    str = val; // replace this line with formatting logic
+    return str;
+  },
+  parse: function(str) {
+    var val;
+    val = str; // replace this line with parse logic
+    return val;
+  },
+  // invalid: function(value) {} // supply if \`parse\` expects clean syntax
+  // expectation: 'optional string describing valid syntax displayed on error'
+};`,
+
+`module.exports = {
+  name: 'trend',
+  format: function(value) {
+    return Math.abs(value).toFixed(2) + (value < 0 ? '⬇' : '⬆');
+  },
+  parse: function(str) {
+    var value = parseFloat(str);
+    
+    // if (isNaN(value)) { throw new SyntaxError('Expected input to start with a floating point number representation optionally prefixed with a negative sign and/or ending with optional optional down-arrow.'); }
+    
+    if (/(^-|⬇$)/.test(str)) { value = -Math.abs(value); }
+    
+    return value; 
+  },
+  invalid: function(str) { return !/^(\\d+(\\.(\\d+)?)?|\\.\\d+)[⬇⬆]$/.test(str); }
+};`,
+
+`var footInchPattern = /^\s*((((\\d+)')?\\s*((\\d+)")?)|\\d+)\\s*$/;
+
+module.exports = {
+  name: 'ft-in',
+  format: function(value) {
+    value = Math.round(value);
+    if (value != null) {
+      var feet = Math.floor(value / 12);
+      value = (feet ? feet + '\\'' : '') + ' ' + (value % 12) + '"';
+    } else {
+      value = null;
+    }
+    return value;
+  },
+  parse: function(str) {
+    var inches, feet,
+      parts = str.match(footInchPattern);
+    if (parts) {
+      feet = parts[4];
+      inches = parts[6];
+      if (feet === undefined && inches === undefined) {
+        inches = Number(parts[1]);
+      } else {
+        feet = Number(feet || 0);
+        inches = Number(inches || 0);
+        inches = 12 * feet + inches;
+      }
+    } else {
+      inches = 0;
+    }
+    return inches;
+  }
+};`,
+
+`module.exports = {
+  name: 'clock24',
+
+  // returns formatted string from number of minutes
+  format: function(mins) {
+    var hh = Math.floor(mins / 60);
+    var mm = (mins % 60 + 100 + '').substr(1, 2);
+    return hh + ':' + mm;
+  },
+
+  invalid: function(hhmm) {
+    return !/^([01]?[1-9]|2[0-3]):[0-5]\\d$/i.test(hhmm); // 23:59 max
+  },
+
+  // returns number of minutes from formatted string
+  parse: function(hhmm) {
+    var parts = hhmm.match(/^(\\d+):(\\d{2})$/i);
+    var value = Number(parts[1]) * 60 + Number(parts[2]);
+    return value;
+  }
+};`,
+
+`var NOON = 12 * 60;
+
+module.exports = {
+  name: 'clock12',
+  
+  // returns formatted string from number of minutes
+  format: function(mins) {
+    var hh = Math.floor(mins / 60) % 12 || 12; // modulo 12 hrs with 0 becoming 12
+    var mm = (mins % 60 + 100 + '').substr(1, 2);
+    var AmPm = mins < NOON ? 'AM' : 'PM';
+    return hh + ':' + mm + ' ' + AmPm;
+  },
+
+  invalid: function(hhmmAmPm) {
+    return !/^(0?[1-9]|1[0-2]):[0-5]\\d\\s+(AM|PM)$/i.test(hhmmAmPm); // 12:59 max
+  },
+
+  // returns number of minutes from formatted string
+  parse: function(hhmmAmPm) {
+    var parts = hhmmAmPm.match(/^(\\d+):(\\d{2})\\s+(AM|PM)$/i);
+    var hours = parts[1] === '12' ? 0 : Number(parts[1]);
+    var minutes = Number(parts[2]);
+    var value = hours * 60 + minutes;
+    var pm = parts[3].toUpperCase() === 'PM';
+    if (pm) { value += NOON; }
+    return value;
+  }
+};`
+
+];

--- a/demo/index.html
+++ b/demo/index.html
@@ -15,6 +15,7 @@
 <body>
 
     <label style="float:right; color:lightgrey; font:bold italic 9pt sans-serif; margin-right:1em; cursor:help"
+     onclick="alert(this.title)"
      title="var grid = new Hypergrid,
     g = grid,
     p = g.properties,

--- a/demo/index.html
+++ b/demo/index.html
@@ -13,6 +13,14 @@
 
 </head>
 <body>
+
+    <label style="float:right; color:lightgrey; font:bold italic 9pt sans-serif; margin-right:1em; cursor:help"
+     title="var grid = new Hypergrid,
+    g = grid,
+    p = g.properties,
+    b = g.behavior,
+    m = b.dataModel;">top-level global vars</label>
+
     <h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.11 dev testbench</h1>
 
     <div id="tabs">

--- a/demo/index.html
+++ b/demo/index.html
@@ -2,7 +2,8 @@
 <html>
 <head>
     <title>fin-hypergrid Demo</title>
-
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" >
+    <meta http-equiv="Cache-Control" content="must-revalidate" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
 
     <script src="data/widedata.js"></script>

--- a/demo/index.html
+++ b/demo/index.html
@@ -12,7 +12,7 @@
 
 </head>
 <body>
-    <h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.9 dev testbench</h1>
+    <h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.11 dev testbench</h1>
 
     <div id="tabs">
         <div id="tab-dashboard">Dashboard</div>

--- a/demo/js/demo/celleditors.js
+++ b/demo/js/demo/celleditors.js
@@ -18,7 +18,7 @@ module.exports = function(demo, grid) {
     var Time = Textfield.extend('Time', {
         template: [
             '<div class="hypergrid-textfield" style="text-align:right;">',
-            '    <input type="text" lang="{{locale}}" style="background-color:transparent; width:75%; text-align:right; border:0; padding:0; outline:0; font-size:inherit; font-weight:inherit;' +
+            '    <input type="text" lang="{{locale}}" style="background-color:transparent; width:75%; text-align:right; border:0; padding:0; outline:0; font:inherit;' +
             '{{style}}">',
             '    <span>AM</span>',
             '</div>'

--- a/demo/js/demo/celleditors.js
+++ b/demo/js/demo/celleditors.js
@@ -43,6 +43,34 @@ module.exports = function(demo, grid) {
             this.input.onblur = function(e) {
                 this.el.style.outline = 0;
             }.bind(this);
+            this.input.onkeypress = function(e) {
+                switch (e.key) {
+                    case 'a': case 'A':
+                        this.meridian.textContent = 'AM';
+                        e.preventDefault();
+                        break;
+                    case 'p': case 'P':
+                        this.meridian.textContent = 'PM';
+                        e.preventDefault();
+                        break;
+                    case 'm': case 'M':
+                        if (/[ap]/i.test(this.previousKeypress)) {
+                            // just ignore M when preceded by A or P
+                            e.preventDefault();
+                            break;
+                        }
+                        // fall through when NOT preceded by A or P
+                    default:
+                        // only allow digits and colon (besides A, P, M as above)
+                        if ('0123456789:'.indexOf(e.key) >= 0) {
+                            break;
+                        }
+                        // FSM jam!
+                        this.errorEffectBegin(); // feedback for unexpected key press
+                        e.preventDefault();
+                }
+                this.previousKeypress = e.key;
+            }.bind(this);
         },
 
         setEditorValue: function(value) {
@@ -53,6 +81,7 @@ module.exports = function(demo, grid) {
         },
 
         getEditorValue: function(value) {
+            delete this.previousKeypress;
             value = CellEditor.prototype.getEditorValue.call(this, value);
             if (this.meridian.textContent === 'PM') {
                 value += demo.NOON;

--- a/demo/js/demo/celleditors.js
+++ b/demo/js/demo/celleditors.js
@@ -18,7 +18,7 @@ module.exports = function(demo, grid) {
     var Time = Textfield.extend('Time', {
         template: [
             '<div class="hypergrid-textfield" style="text-align:right;">',
-            '    <input type="text" lang="{{locale}}" style="background-color:transparent; width:75%; text-align:right; border:0; padding:0; outline:0; font:inherit;' +
+            '    <input type="text" lang="{{locale}}" style="background-color:transparent; width:60%; text-align:right; border:0; padding:0; outline:0; font:inherit;' +
             '{{style}}">',
             '    <span>AM</span>',
             '</div>'
@@ -31,38 +31,20 @@ module.exports = function(demo, grid) {
             // Flip AM/PM on any click
             this.el.onclick = function() {
                 this.meridian.textContent = this.meridian.textContent === 'AM' ? 'PM' : 'AM';
+                this.input.focus(); // return focus to text field
             }.bind(this);
-            this.input.onclick = function(e) {
-                e.stopPropagation(); // ignore clicks in the text field
-            };
-            this.input.onfocus = function(e) {
-                var target = e.target;
-                this.el.style.outline = this.outline = this.outline || window.getComputedStyle(target).outline;
-                target.style.outline = 0;
-            }.bind(this);
-            this.input.onblur = function(e) {
-                this.el.style.outline = 0;
-            }.bind(this);
+
+            // Flip AM/PM on 'am' or 'pm' keypresses
             this.input.onkeypress = function(e) {
                 switch (e.key) {
-                    case 'a': case 'A':
-                        this.meridian.textContent = 'AM';
-                        e.preventDefault();
-                        break;
-                    case 'p': case 'P':
-                        this.meridian.textContent = 'PM';
-                        e.preventDefault();
-                        break;
+                    case 'a': case 'A': this.meridian.textContent = 'AM'; e.preventDefault(); break;
+                    case 'p': case 'P': this.meridian.textContent = 'PM'; e.preventDefault(); break;
                     case 'm': case 'M':
-                        if (/[ap]/i.test(this.previousKeypress)) {
-                            // just ignore M when preceded by A or P
-                            e.preventDefault();
-                            break;
-                        }
-                        // fall through when NOT preceded by A or P
+                        if (/[ap]/i.test(this.previousKeypress)) { e.preventDefault(); break; }
+                        // fall through to FSM when M NOT preceded by A or P
                     default:
-                        // only allow digits and colon (besides A, P, M as above)
-                        if ('0123456789:'.indexOf(e.key) >= 0) {
+                        // only allow digits and colon (besides A, P, M as above) and specials (ENTER, TAB, ESC)
+                        if ('0123456789:'.indexOf(e.key) >= 0 || this.specialKeyups[e.keyCode]) {
                             break;
                         }
                         // FSM jam!
@@ -74,7 +56,7 @@ module.exports = function(demo, grid) {
         },
 
         setEditorValue: function(value) {
-            CellEditor.prototype.setEditorValue.call(this, value);
+            this.super.setEditorValue.call(this, value);
             var parts = this.input.value.split(' ');
             this.input.value = parts[0];
             this.meridian.textContent = parts[1];
@@ -82,11 +64,11 @@ module.exports = function(demo, grid) {
 
         getEditorValue: function(value) {
             delete this.previousKeypress;
-            value = CellEditor.prototype.getEditorValue.call(this, value);
-            if (this.meridian.textContent === 'PM') {
-                value += demo.NOON;
-            }
-            return value;
+            return this.super.getEditorValue.call(this, value + ' ' + this.meridian.textContent);
+        },
+
+        validateEditorValue: function(value) {
+            return this.super.validateEditorValue.call(this, value + ' ' + this.meridian.textContent);
         }
     });
 

--- a/demo/js/demo/dashboard.js
+++ b/demo/js/demo/dashboard.js
@@ -65,12 +65,10 @@ module.exports = function(demo, grid) {
             label: 'Selection',
             ctrls: [
                 {
-                    name: 'checkboxOnlyRowSelections', label: 'by row handles only', setter: setSelectionProp,
-                    tooltip: 'Note that when this property is active, autoSelectRows will not work.'
-                },
-                {
-                    name: 'singleRowSelectionMode',
-                    label: 'one row at a time',
+                    name: 'cellSelection',
+                    label: 'cells',
+                    weight: 'bold',
+                    tooltip: 'Basic cell selectability.',
                     setter: setSelectionProp
                 },
                 {
@@ -80,22 +78,45 @@ module.exports = function(demo, grid) {
                     checked: true
                 },
                 {
+                    name: 'collapseCellSelections',
+                    label: 'collapse cell selections',
+                    setter: setSelectionProp,
+                    tooltip: 'Cell selections are projected onto subsequently selected rows.\n\n' +
+                    'Requires singleRowSelectionMode && !multipleSelections.'
+                },
+                {
+                    name: 'rowSelection',
+                    label: 'rows',
+                    weight: 'bold',
+                    tooltip: 'Basic row selectability.',
+                    setter: setSelectionProp
+                },
+                {
                     name: 'autoSelectRows', label: 'auto-select rows', setter: setSelectionProp,
                     tooltip: 'Notes:\n' +
                     '1. Requires that checkboxOnlyRowSelections be set to false (so checking this box automatically unchecks that one).\n' +
                     '2. Set singleRowSelectionMode to false to allow auto-select of multiple rows.'
                 },
                 {
-                    name: 'autoSelectColumns',
-                    label: 'auto-select columns',
+                    name: 'checkboxOnlyRowSelections', label: 'by row handles only', setter: setSelectionProp,
+                    tooltip: 'Note that when this property is active, autoSelectRows will not work.'
+                },
+                {
+                    name: 'singleRowSelectionMode',
+                    label: 'one row at a time',
                     setter: setSelectionProp
                 },
                 {
-                    name: 'collapseCellSelections',
-                    label: 'collapse cell selections',
-                    setter: setSelectionProp,
-                    tooltip: 'Cell selections are projected onto subsequently selected rows.\n\n' +
-                        'Requires singleRowSelectionMode && !multipleSelections.'
+                    name: 'columnSelection',
+                    label: 'columns',
+                    weight: 'bold',
+                    tooltip: 'Basic column selectability.',
+                    setter: setSelectionProp
+                },
+                {
+                    name: 'autoSelectColumns',
+                    label: 'auto-select columns',
+                    setter: setSelectionProp
                 }
             ]
         }
@@ -195,6 +216,7 @@ module.exports = function(demo, grid) {
 
             label = document.createElement('label');
             label.title = tooltip;
+            label.style.fontWeight = ctrl.weight;
             label.appendChild(input);
             label.insertBefore(
                 document.createTextNode(' ' + (ctrl.label || ctrl.name)),

--- a/demo/js/demo/dashboard.js
+++ b/demo/js/demo/dashboard.js
@@ -68,7 +68,11 @@ module.exports = function(demo, grid) {
                     name: 'checkboxOnlyRowSelections', label: 'by row handles only', setter: setSelectionProp,
                     tooltip: 'Note that when this property is active, autoSelectRows will not work.'
                 },
-                {name: 'singleRowSelectionMode', label: 'one row at a time', setter: setSelectionProp},
+                {
+                    name: 'singleRowSelectionMode',
+                    label: 'one row at a time',
+                    setter: setSelectionProp
+                },
                 {
                     name: '!multipleSelections',
                     label: 'one cell region at a time',
@@ -81,7 +85,18 @@ module.exports = function(demo, grid) {
                     '1. Requires that checkboxOnlyRowSelections be set to false (so checking this box automatically unchecks that one).\n' +
                     '2. Set singleRowSelectionMode to false to allow auto-select of multiple rows.'
                 },
-                {name: 'autoSelectColumns', label: 'auto-select columns', setter: setSelectionProp}
+                {
+                    name: 'autoSelectColumns',
+                    label: 'auto-select columns',
+                    setter: setSelectionProp
+                },
+                {
+                    name: 'collapseCellSelections',
+                    label: 'collapse cell selections',
+                    setter: setSelectionProp,
+                    tooltip: 'Cell selections are projected onto subsequently selected rows.\n\n' +
+                        'Requires singleRowSelectionMode && !multipleSelections.'
+                }
             ]
         }
     ];

--- a/demo/js/demo/dashboard.js
+++ b/demo/js/demo/dashboard.js
@@ -369,7 +369,6 @@ module.exports = function(demo, grid) {
         var ctrl;
 
         grid.selectionModel.clear();
-        grid.behavior.dataModel.clearSelectedData();
 
         setProp.call(this);
 

--- a/demo/js/demo/events.js
+++ b/demo/js/demo/events.js
@@ -94,28 +94,7 @@ module.exports = function(demo, grid) {
     });
 
     grid.addEventListener('fin-row-selection-changed', function(e) {
-        var detail = e.detail;
-        // Move cell selection with row selection
-        var rows = detail.rows,
-            selections = detail.selections;
-        if (
-            grid.properties.singleRowSelectionMode && // let's only attempt this when in this mode
-            !grid.properties.multipleSelections && // and only when in single selection mode
-            rows.length && // user just selected a row (must be single row due to mode we're in)
-            selections.length  // there was a cell region selected (must be the only one)
-        ) {
-            var rect = grid.selectionModel.getLastSelection(), // the only cell selection
-                x = rect.left,
-                y = rows[0], // we know there's only 1 row selected
-                width = rect.right - x,
-                height = 0, // collapse the new region to occupy a single row
-                fireSelectionChangedEvent = false;
-
-            grid.selectionModel.select(x, y, width, height, fireSelectionChangedEvent);
-            grid.repaint();
-        }
-
-        if (rows.length === 0) {
+        if (e.detail.rows.length === 0) {
             console.log('no rows selected');
             return;
         }

--- a/demo/js/demo/events.js
+++ b/demo/js/demo/events.js
@@ -3,7 +3,7 @@
 module.exports = function(demo, grid) {
 
     grid.addEventListener('fin-button-pressed', function(e) {
-        var cellEvent = e.detail;
+        var cellEvent = e.detail.primitiveEvent;
         cellEvent.value = !cellEvent.value;
     });
 

--- a/demo/js/demo/formatters.js
+++ b/demo/js/demo/formatters.js
@@ -50,25 +50,31 @@ module.exports = function(demo, grid) {
         currency: 'EUR'
     }));
 
+    var NOON = 12 * 60;
     grid.localization.add({
-        name: 'hhmm', // alternative to having to hame localizer in `grid.localization.add`
+        name: 'clock12', // alternative to having to hame localizer in `grid.localization.add`
 
-        // returns formatted string from number
+        // returns formatted string from number of minutes
         format: function(mins) {
-            var hh = Math.floor(mins / 60) % 12 || 12, // modulo 12 hrs with 0 becoming 12
-                mm = (mins % 60 + 100 + '').substr(1, 2),
-                AmPm = mins < demo.NOON ? 'AM' : 'PM';
+            var hh = Math.floor(mins / 60) % 12 || 12; // modulo 12 hrs with 0 becoming 12
+            var mm = (mins % 60 + 100 + '').substr(1, 2);
+            var AmPm = mins < NOON ? 'AM' : 'PM';
             return hh + ':' + mm + ' ' + AmPm;
         },
 
-        invalid: function(hhmm) {
-            return !/^(0?[1-9]|1[0-2]):[0-5]\d$/.test(hhmm); // 12:59 max
+        invalid: function(hhmmAmPm) {
+            return !/^(0?[1-9]|1[0-2]):[0-5]\d\s+(AM|PM)$/i.test(hhmmAmPm); // 12:59 max
         },
 
-        // returns number from formatted string
-        parse: function(hhmm) {
-            var parts = hhmm.match(/^(\d+):(\d{2})$/);
-            return Number(parts[1]) * 60 + Number(parts[2]);
+        // returns number of minutes from formatted string
+        parse: function(hhmmAmPm) {
+            var parts = hhmmAmPm.match(/^(\d+):(\d{2})\s+(AM|PM)$/i);
+            var hours = parts[1] === '12' ? 0 : Number(parts[1]);
+            var minutes = Number(parts[2]);
+            var value = hours * 60 + minutes;
+            var pm = parts[3].toUpperCase() === 'PM';
+            if (pm) { value += NOON; }
+            return value;
         }
     });
 

--- a/demo/js/demo/index.js
+++ b/demo/js/demo/index.js
@@ -10,6 +10,7 @@ window.onload = function() {
 
     var demo = window.demo = {
         set vent(start) { window.grid[start ? 'logStart' : 'logStop'](); },
+        NOON: 12 * 60, // used by `hhmm` localizer and `Time` cell editor
         reset: reset,
         setData: setData,
         toggleEmptyData: toggleEmptyData,

--- a/demo/js/demo/index.js
+++ b/demo/js/demo/index.js
@@ -44,11 +44,15 @@ window.onload = function() {
             plugins: require('fin-hypergrid-event-logger'),
             state: { color: 'orange' }
         },
-        grid = window.grid = window.g = new Hypergrid('div#json-example', gridOptions),
-        behavior = window.b = grid.behavior,
-        dataModel = window.m = behavior.dataModel,
+        grid = new Hypergrid('div#json-example', gridOptions),
+        behavior = grid.behavior,
+        dataModel = behavior.dataModel,
         idx = behavior.columnEnum;
 
+    window.g = window.grid = grid;
+    window.p = grid.properties;
+    window.b = behavior;
+    window.m = dataModel;
 
     console.log('Fields:');  console.dir(behavior.dataModel.schema.map(function(cs) { return cs.name; }));
     console.log('Headers:'); console.dir(behavior.dataModel.schema.map(function(cs) { return cs.header; }));

--- a/demo/js/demo/index.js
+++ b/demo/js/demo/index.js
@@ -10,7 +10,6 @@ window.onload = function() {
 
     var demo = window.demo = {
         set vent(start) { window.grid[start ? 'logStart' : 'logStop'](); },
-        NOON: 12 * 60, // used by `hhmm` localizer and `Time` cell editor
         reset: reset,
         setData: setData,
         toggleEmptyData: toggleEmptyData,

--- a/demo/js/demo/setState.js
+++ b/demo/js/demo/setState.js
@@ -104,7 +104,7 @@ module.exports = function(demo, grid) {
             birthTime: {
                 halign: 'right',
                 editor: 'time',
-                format: 'hhmm'
+                format: 'clock12'
             },
 
             birthState: {

--- a/demo/js/demo/setState.js
+++ b/demo/js/demo/setState.js
@@ -47,8 +47,6 @@ module.exports = function(demo, grid) {
 
         checkboxOnlyRowSelections: true,
 
-        autoSelectRows: true,
-
         rows: {
             header: {
                 0: {

--- a/demo/multiple-grids.html
+++ b/demo/multiple-grids.html
@@ -5,7 +5,7 @@
     <style> body > div.hypergrid-container { width: 415px; margin-right: 10px; display: inline-block }</style>
 </head>
 <body>
-<h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.9 multiple grids demo</h1>
+<h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.11 multiple grids demo</h1>
 
 <script src="build/fin-hypergrid.js"></script>
 

--- a/demo/row-props.html
+++ b/demo/row-props.html
@@ -38,7 +38,7 @@
     </style>
 </head>
 <body>
-<h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.9 performance workbench</h1>
+<h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.11 performance workbench</h1>
 
 <div id="controls" class="nowrap">
     <label id="controller" title="Uncheck to hide other controls.">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fin-hypergrid",
-  "version": "2.1.9",
+  "version": "2.1.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2242,9 +2242,9 @@
       }
     },
     "finbars": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/finbars/-/finbars-1.5.2.tgz",
-      "integrity": "sha1-aiTatNQUxcXmp+nPNTqW0fdy+hc=",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/finbars/-/finbars-1.6.0.tgz",
+      "integrity": "sha512-ZqKMygrNOkFIacc5M1ShGCfe17CmYQb7cNO8N+LVSM275/uTNARcXrkN/K5zInnZ04y6BvooXPiWi996859zLQ==",
       "requires": {
         "css-injector": "1.1.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "JSONStream": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
-      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.3.tgz",
+      "integrity": "sha512-3Sp6WZZ/lXl+nTDoGpGWHEpTnnC6X5fnkolYZR6nwIfzbxxvA8utPWe1gCt7i0m9uVGsSz2IS8K8mJ7HmlduMg==",
       "dev": true,
       "requires": {
         "jsonparse": "1.3.1",
@@ -72,13 +72,15 @@
       "dev": true
     },
     "ajv": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "dev": true,
       "requires": {
         "co": "4.6.0",
-        "json-stable-stringify": "1.0.1"
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "ajv-keywords": {
@@ -244,12 +246,6 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
-    "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-      "dev": true
-    },
     "asn1.js": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
@@ -269,12 +265,6 @@
       "requires": {
         "util": "0.10.3"
       }
-    },
-    "assert-plus": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-      "dev": true
     },
     "assertion-error": {
       "version": "1.1.0",
@@ -320,16 +310,10 @@
       "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
       "dev": true
     },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
-    },
     "atob": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.0.tgz",
-      "integrity": "sha512-SuiKH8vbsOyCALjA/+EINmt/Kdl+TQPrtFgW7XZZcwtryFu9e5kQoX3bjCW6mIvGH1fbeAZZuvwGR5IlBRznGw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
+      "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio=",
       "dev": true
     },
     "automat": {
@@ -337,17 +321,15 @@
       "resolved": "https://registry.npmjs.org/automat/-/automat-1.2.0.tgz",
       "integrity": "sha1-aNIvHhQzjitBCByeyZG22XSwYzA="
     },
-    "aws-sign2": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-      "dev": true
-    },
-    "aws4": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
-      "dev": true
+    "axios": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
+      "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "1.5.0",
+        "is-buffer": "1.1.6"
+      }
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -446,9 +428,9 @@
       "dev": true
     },
     "base64-js": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.3.tgz",
-      "integrity": "sha512-MsAhsUW1GxCdgYSO6tAfZrNapmUKk7mWx/k5mFY/A1gBtkaCaNapTg+FExCw1r9yeaZhqx/xPg43xgTFH6KL5w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
       "dev": true
     },
     "base64id": {
@@ -462,16 +444,6 @@
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
       "integrity": "sha1-PzQU84AyF0O/wQQvmoP/HVgk1GQ=",
       "dev": true
-    },
-    "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "tweetnacl": "0.14.5"
-      }
     },
     "beeper": {
       "version": "1.1.1",
@@ -507,7 +479,7 @@
       "dev": true,
       "requires": {
         "readable-stream": "2.3.6",
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "blob": {
@@ -521,15 +493,6 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
       "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
       "dev": true
-    },
-    "boom": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "dev": true,
-      "requires": {
-        "hoek": "2.16.3"
-      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -564,10 +527,10 @@
       "integrity": "sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.2",
+        "JSONStream": "1.3.3",
         "combine-source-map": "0.8.0",
         "defined": "1.0.0",
-        "safe-buffer": "5.1.1",
+        "safe-buffer": "5.1.2",
         "through2": "2.0.3",
         "umd": "3.0.3"
       }
@@ -590,9 +553,9 @@
       }
     },
     "browser-sync": {
-      "version": "2.23.6",
-      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.23.6.tgz",
-      "integrity": "sha512-loCO5NQKZXfBJrEvmLwF1TPSECCsPopNd29qduoysLmpw8op2lgolGMjz3oI/MjG4duzB9TfDs7k58djRSwPwg==",
+      "version": "2.24.4",
+      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.24.4.tgz",
+      "integrity": "sha512-qfXv8vQA/Dctub2v44v/vPuvfC4XNd6bn+W5vWZVuhuy6w91lPsdY6qhalT2s2PjnJ3FR6kWq5wkTQgN26eKzA==",
       "dev": true,
       "requires": {
         "browser-sync-ui": "1.0.1",
@@ -603,24 +566,24 @@
         "dev-ip": "1.0.1",
         "easy-extender": "2.3.2",
         "eazy-logger": "3.0.2",
-        "emitter-steward": "1.0.0",
         "etag": "1.8.1",
         "fresh": "0.5.2",
         "fs-extra": "3.0.1",
         "http-proxy": "1.15.2",
         "immutable": "3.8.2",
-        "localtunnel": "1.8.3",
+        "localtunnel": "1.9.0",
         "micromatch": "2.3.11",
         "opn": "4.0.2",
         "portscanner": "2.1.1",
-        "qs": "6.2.1",
+        "qs": "6.2.3",
+        "raw-body": "2.3.3",
         "resp-modifier": "6.0.2",
         "rx": "4.1.0",
         "serve-index": "1.8.0",
-        "serve-static": "1.12.2",
+        "serve-static": "1.13.2",
         "server-destroy": "1.0.1",
         "socket.io": "2.0.4",
-        "ua-parser-js": "0.7.12",
+        "ua-parser-js": "0.7.17",
         "yargs": "6.4.0"
       }
     },
@@ -644,7 +607,7 @@
       "integrity": "sha512-IHYyFPm2XjJCL+VV0ZtFv8wn/sAHVOm83q3yfSn8YWbZ9jcybgPKxSDdiuMU+35jUL1914l74RnXXPD9Iyo9yg==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.2",
+        "JSONStream": "1.3.3",
         "assert": "1.4.1",
         "browser-pack": "6.1.0",
         "browser-resolve": "1.11.2",
@@ -665,7 +628,7 @@
         "htmlescape": "1.1.1",
         "https-browserify": "1.0.0",
         "inherits": "2.0.3",
-        "insert-module-globals": "7.0.6",
+        "insert-module-globals": "7.1.0",
         "labeled-stream-splicer": "2.0.1",
         "mkdirp": "0.5.1",
         "module-deps": "5.0.1",
@@ -681,7 +644,7 @@
         "shasum": "1.0.2",
         "shell-quote": "1.6.1",
         "stream-browserify": "2.0.1",
-        "stream-http": "2.8.1",
+        "stream-http": "2.8.2",
         "string_decoder": "1.0.3",
         "subarg": "1.0.0",
         "syntax-error": "1.4.0",
@@ -700,7 +663,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "5.1.2"
           }
         }
       }
@@ -716,7 +679,7 @@
         "create-hash": "1.2.0",
         "evp_bytestokey": "1.0.3",
         "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "browserify-cipher": {
@@ -787,7 +750,7 @@
       "integrity": "sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==",
       "dev": true,
       "requires": {
-        "base64-js": "1.2.3",
+        "base64-js": "1.3.0",
         "ieee754": "1.1.11"
       }
     },
@@ -813,6 +776,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
+      "dev": true
+    },
+    "bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
       "dev": true
     },
     "cache-base": {
@@ -868,15 +837,9 @@
       "dev": true
     },
     "camelcase": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-      "dev": true
-    },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+      "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
       "dev": true
     },
     "chai": {
@@ -916,7 +879,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
-        "fsevents": "1.1.3",
+        "fsevents": "1.2.4",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -932,7 +895,7 @@
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "circular-json": {
@@ -1090,15 +1053,6 @@
         "source-map": "0.5.7"
       }
     },
-    "combined-stream": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-      "dev": true,
-      "requires": {
-        "delayed-stream": "1.0.0"
-      }
-    },
     "commander": {
       "version": "2.15.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
@@ -1175,9 +1129,9 @@
       }
     },
     "concat-with-sourcemaps": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.5.tgz",
-      "integrity": "sha512-YtnS0VEY+e2Khzsey/6mra9EoM6h/5gxaC0e3mcHpA5yfDxafhygytNmcJWodvUgyXzSiL5MSkPO6bQGgfliHw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.1.0.tgz",
+      "integrity": "sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==",
       "dev": true,
       "requires": {
         "source-map": "0.6.1"
@@ -1266,9 +1220,9 @@
       "dev": true
     },
     "create-ecdh": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.1.tgz",
-      "integrity": "sha512-iZvCCg8XqHQZ1ioNBTzXS/cQSkqkqcPs8xSX4upNB+DAk9Ht3uzQf2J32uAHNCne8LDmKr29AgZrEs4oIrwLuQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
+      "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
       "dev": true,
       "requires": {
         "bn.js": "4.11.8",
@@ -1284,7 +1238,7 @@
         "cipher-base": "1.0.4",
         "inherits": "2.0.3",
         "md5.js": "1.3.4",
-        "ripemd160": "2.0.1",
+        "ripemd160": "2.0.2",
         "sha.js": "2.4.11"
       }
     },
@@ -1297,8 +1251,8 @@
         "cipher-base": "1.0.4",
         "create-hash": "1.2.0",
         "inherits": "2.0.3",
-        "ripemd160": "2.0.1",
-        "safe-buffer": "5.1.1",
+        "ripemd160": "2.0.2",
+        "safe-buffer": "5.1.2",
         "sha.js": "2.4.11"
       }
     },
@@ -1308,30 +1262,21 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.2",
+        "lru-cache": "4.1.3",
         "shebang-command": "1.2.0",
         "which": "1.3.0"
       },
       "dependencies": {
         "lru-cache": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
-          "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+          "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
           "dev": true,
           "requires": {
             "pseudomap": "1.0.2",
             "yallist": "2.1.2"
           }
         }
-      }
-    },
-    "cryptiles": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "dev": true,
-      "requires": {
-        "boom": "2.10.1"
       }
     },
     "crypto-browserify": {
@@ -1342,12 +1287,12 @@
       "requires": {
         "browserify-cipher": "1.0.1",
         "browserify-sign": "4.0.4",
-        "create-ecdh": "4.0.1",
+        "create-ecdh": "4.0.3",
         "create-hash": "1.2.0",
         "create-hmac": "1.1.7",
         "diffie-hellman": "5.0.3",
         "inherits": "2.0.3",
-        "pbkdf2": "3.0.14",
+        "pbkdf2": "3.0.16",
         "public-encrypt": "4.0.2",
         "randombytes": "2.0.6",
         "randomfill": "1.0.4"
@@ -1357,23 +1302,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/css-injector/-/css-injector-1.1.0.tgz",
       "integrity": "sha1-SG/U3E+EcN7wBxRwQ0RS8gM+xPo="
-    },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
-      }
     },
     "date-now": {
       "version": "0.1.4",
@@ -1512,12 +1440,6 @@
         "rimraf": "2.6.2"
       }
     },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
-    },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -1536,7 +1458,7 @@
       "integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.2",
+        "JSONStream": "1.3.3",
         "shasum": "1.0.2",
         "subarg": "1.0.0",
         "through2": "2.0.3"
@@ -1646,16 +1568,6 @@
         "tfunk": "3.1.0"
       }
     },
-    "ecc-jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "jsbn": "0.1.1"
-      }
-    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -1676,12 +1588,6 @@
         "minimalistic-assert": "1.0.1",
         "minimalistic-crypto-utils": "1.0.1"
       }
-    },
-    "emitter-steward": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/emitter-steward/-/emitter-steward-1.0.0.tgz",
-      "integrity": "sha1-80Ea3pdYp1Zd+Eiy2gy70bRsvWQ=",
-      "dev": true
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -1775,7 +1681,7 @@
         "arraybuffer.slice": "0.0.7",
         "base64-arraybuffer": "0.1.5",
         "blob": "0.0.4",
-        "has-binary2": "1.0.2"
+        "has-binary2": "1.0.3"
       }
     },
     "error-ex": {
@@ -1807,7 +1713,7 @@
       "requires": {
         "ajv": "5.5.2",
         "babel-code-frame": "6.26.0",
-        "chalk": "2.3.2",
+        "chalk": "2.4.1",
         "concat-stream": "1.6.2",
         "cross-spawn": "5.1.0",
         "debug": "3.1.0",
@@ -1820,15 +1726,15 @@
         "file-entry-cache": "2.0.0",
         "functional-red-black-tree": "1.0.1",
         "glob": "7.1.2",
-        "globals": "11.4.0",
-        "ignore": "3.3.7",
+        "globals": "11.5.0",
+        "ignore": "3.3.8",
         "imurmurhash": "0.1.4",
         "inquirer": "3.3.0",
         "is-resolvable": "1.1.0",
         "js-yaml": "3.11.0",
         "json-stable-stringify-without-jsonify": "1.0.1",
         "levn": "0.3.0",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
         "natural-compare": "1.4.0",
@@ -1845,18 +1751,6 @@
         "text-table": "0.2.0"
       },
       "dependencies": {
-        "ajv": {
-          "version": "5.5.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-          "dev": true,
-          "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.1.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
-          }
-        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -1873,14 +1767,14 @@
           }
         },
         "chalk": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.1",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "5.3.0"
+            "supports-color": "5.4.0"
           }
         },
         "concat-stream": {
@@ -1905,9 +1799,9 @@
           }
         },
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
           "dev": true
         },
         "strip-ansi": {
@@ -1920,9 +1814,9 @@
           }
         },
         "supports-color": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
             "has-flag": "3.0.0"
@@ -2008,7 +1902,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {
@@ -2040,7 +1934,7 @@
       "dev": true,
       "requires": {
         "md5.js": "1.3.4",
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "expand-brackets": {
@@ -2058,7 +1952,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "2.2.3"
+        "fill-range": "2.2.4"
       }
     },
     "expand-tilde": {
@@ -2109,7 +2003,7 @@
       "dev": true,
       "requires": {
         "chardet": "0.4.2",
-        "iconv-lite": "0.4.21",
+        "iconv-lite": "0.4.23",
         "tmp": "0.0.33"
       }
     },
@@ -2121,12 +2015,6 @@
       "requires": {
         "is-extglob": "1.0.0"
       }
-    },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
     },
     "fancy-log": {
       "version": "1.3.2",
@@ -2183,14 +2071,14 @@
       "dev": true
     },
     "fill-range": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
       "dev": true,
       "requires": {
         "is-number": "2.1.0",
         "isobject": "2.1.0",
-        "randomatic": "1.1.7",
+        "randomatic": "3.0.0",
         "repeat-element": "1.1.2",
         "repeat-string": "1.6.1"
       }
@@ -2605,6 +2493,26 @@
         "write": "0.2.1"
       }
     },
+    "follow-redirects": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
+      "integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
+      "dev": true,
+      "requires": {
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -2618,23 +2526,6 @@
       "dev": true,
       "requires": {
         "for-in": "1.0.2"
-      }
-    },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
-    },
-    "form-data": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-      "dev": true,
-      "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.6",
-        "mime-types": "2.1.18"
       }
     },
     "fragment-cache": {
@@ -2682,31 +2573,21 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
-      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
       "dev": true,
       "optional": true,
       "requires": {
         "nan": "2.10.0",
-        "node-pre-gyp": "0.6.39"
+        "node-pre-gyp": "0.10.0"
       },
       "dependencies": {
         "abbrev": {
-          "version": "1.1.0",
+          "version": "1.1.1",
           "bundled": true,
           "dev": true,
           "optional": true
-        },
-        "ajv": {
-          "version": "4.11.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
         },
         "ansi-regex": {
           "version": "2.1.1",
@@ -2714,7 +2595,7 @@
           "dev": true
         },
         "aproba": {
-          "version": "1.1.1",
+          "version": "1.2.0",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -2726,91 +2607,25 @@
           "optional": true,
           "requires": {
             "delegates": "1.0.0",
-            "readable-stream": "2.2.9"
+            "readable-stream": "2.3.6"
           }
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
         },
         "balanced-match": {
-          "version": "0.4.2",
-          "bundled": true,
-          "dev": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        },
-        "boom": {
-          "version": "2.10.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "balanced-match": "0.4.2",
-            "concat-map": "0.0.1"
-          }
-        },
-        "buffer-shims": {
           "version": "1.0.0",
           "bundled": true,
           "dev": true
         },
-        "caseless": {
-          "version": "0.12.0",
+        "brace-expansion": {
+          "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
         },
-        "co": {
-          "version": "4.6.0",
+        "chownr": {
+          "version": "1.0.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -2819,14 +2634,6 @@
           "version": "1.1.0",
           "bundled": true,
           "dev": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
         },
         "concat-map": {
           "version": "0.0.1",
@@ -2841,35 +2648,11 @@
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "bundled": true,
           "dev": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
+          "optional": true
         },
         "debug": {
-          "version": "2.6.8",
+          "version": "2.6.9",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2878,15 +2661,10 @@
           }
         },
         "deep-extend": {
-          "version": "0.4.2",
+          "version": "0.5.1",
           "bundled": true,
           "dev": true,
           "optional": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
         },
         "delegates": {
           "version": "1.0.0",
@@ -2895,74 +2673,25 @@
           "optional": true
         },
         "detect-libc": {
-          "version": "1.0.2",
+          "version": "1.0.3",
           "bundled": true,
           "dev": true,
           "optional": true
         },
-        "ecc-jsbn": {
-          "version": "0.1.1",
+        "fs-minipass": {
+          "version": "1.2.5",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "extsprintf": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
+            "minipass": "2.2.4"
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
-        },
-        "fstream": {
-          "version": "1.0.11",
-          "bundled": true,
           "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
-          }
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
-          }
+          "optional": true
         },
         "gauge": {
           "version": "2.7.4",
@@ -2970,7 +2699,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "1.1.1",
+            "aproba": "1.2.0",
             "console-control-strings": "1.1.0",
             "has-unicode": "2.0.1",
             "object-assign": "4.1.1",
@@ -2980,27 +2709,11 @@
             "wide-align": "1.1.2"
           }
         },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
         "glob": {
           "version": "7.1.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "fs.realpath": "1.0.0",
             "inflight": "1.0.6",
@@ -3010,64 +2723,35 @@
             "path-is-absolute": "1.0.1"
           }
         },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true,
-          "dev": true
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
-          }
-        },
         "has-unicode": {
           "version": "2.0.1",
           "bundled": true,
           "dev": true,
           "optional": true
         },
-        "hawk": {
-          "version": "3.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "bundled": true,
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
+        "iconv-lite": {
+          "version": "0.4.21",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.0"
+            "safer-buffer": "2.1.2"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimatch": "3.0.4"
           }
         },
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "once": "1.4.0",
             "wrappy": "1.0.2"
@@ -3079,7 +2763,7 @@
           "dev": true
         },
         "ini": {
-          "version": "1.3.4",
+          "version": "1.3.5",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -3092,110 +2776,42 @@
             "number-is-nan": "1.0.1"
           }
         },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true,
           "dev": true,
           "optional": true
-        },
-        "jodid25519": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jsprim": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.0.2",
-            "json-schema": "0.2.3",
-            "verror": "1.3.6"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "mime-db": {
-          "version": "1.27.0",
-          "bundled": true,
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.15",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "mime-db": "1.27.0"
-          }
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
           "dev": true
+        },
+        "minipass": {
+          "version": "2.2.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
+          }
+        },
+        "minizlib": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "2.2.4"
+          }
         },
         "mkdirp": {
           "version": "0.5.1",
@@ -3211,23 +2827,33 @@
           "dev": true,
           "optional": true
         },
-        "node-pre-gyp": {
-          "version": "0.6.39",
+        "needle": {
+          "version": "2.2.0",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "1.0.2",
-            "hawk": "3.1.3",
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.21",
+            "sax": "1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.10.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.3",
             "mkdirp": "0.5.1",
+            "needle": "2.2.0",
             "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
-            "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
+            "npm-packlist": "1.1.10",
+            "npmlog": "4.1.2",
+            "rc": "1.2.7",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "4.4.1"
           }
         },
         "nopt": {
@@ -3236,12 +2862,28 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.1.10",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
           }
         },
         "npmlog": {
-          "version": "4.1.0",
+          "version": "4.1.2",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -3256,12 +2898,6 @@
           "version": "1.0.1",
           "bundled": true,
           "dev": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3290,7 +2926,7 @@
           "optional": true
         },
         "osenv": {
-          "version": "0.1.4",
+          "version": "0.1.5",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -3302,39 +2938,23 @@
         "path-is-absolute": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "bundled": true,
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
-          "version": "1.0.7",
-          "bundled": true,
-          "dev": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "qs": {
-          "version": "6.4.0",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "rc": {
-          "version": "1.2.1",
+          "version": "1.2.7",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
+            "deep-extend": "0.5.1",
+            "ini": "1.3.5",
             "minimist": "1.2.0",
             "strip-json-comments": "2.0.1"
           },
@@ -3348,64 +2968,48 @@
           }
         },
         "readable-stream": {
-          "version": "2.2.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "request": {
-          "version": "2.81.0",
+          "version": "2.3.6",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "rimraf": {
-          "version": "2.6.1",
+          "version": "2.6.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "glob": "7.1.2"
           }
         },
         "safe-buffer": {
-          "version": "5.0.1",
+          "version": "5.1.1",
           "bundled": true,
           "dev": true
         },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
         "semver": {
-          "version": "5.3.0",
+          "version": "5.5.0",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -3422,39 +3026,6 @@
           "dev": true,
           "optional": true
         },
-        "sntp": {
-          "version": "1.0.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "sshpk": {
-          "version": "1.13.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -3466,18 +3037,13 @@
           }
         },
         "string_decoder": {
-          "version": "1.0.1",
+          "version": "1.1.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "safe-buffer": "5.0.1"
+            "safe-buffer": "5.1.1"
           }
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
         },
         "strip-ansi": {
           "version": "3.0.1",
@@ -3494,80 +3060,25 @@
           "optional": true
         },
         "tar": {
-          "version": "2.2.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
-          }
-        },
-        "tar-pack": {
-          "version": "3.4.0",
+          "version": "4.4.1",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.4",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
           }
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true
         },
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "bundled": true,
           "dev": true,
           "optional": true
-        },
-        "verror": {
-          "version": "1.3.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "extsprintf": "1.0.2"
-          }
         },
         "wide-align": {
           "version": "1.1.2",
@@ -3580,6 +3091,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.0.2",
           "bundled": true,
           "dev": true
         }
@@ -3617,23 +3133,6 @@
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
-    },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
-      }
     },
     "glob": {
       "version": "7.1.2",
@@ -3782,9 +3281,9 @@
       }
     },
     "globals": {
-      "version": "11.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.4.0.tgz",
-      "integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA==",
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.5.0.tgz",
+      "integrity": "sha512-hYyf+kI8dm3nORsiiXUQigOU62hDLfJ9G01uyGMxhc6BKsircrUhC4uJPQPUSuq2GrTmiiEt7ewxlMdBewfmKQ==",
       "dev": true
     },
     "globby": {
@@ -3859,7 +3358,7 @@
       "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
       "dev": true,
       "requires": {
-        "sparkles": "1.0.0"
+        "sparkles": "1.0.1"
       }
     },
     "graceful-fs": {
@@ -3914,15 +3413,15 @@
       "integrity": "sha1-Yz0WyV2IUEYorQJmVmPO5aR5M1M=",
       "dev": true,
       "requires": {
-        "concat-with-sourcemaps": "1.0.5",
+        "concat-with-sourcemaps": "1.1.0",
         "through2": "2.0.3",
         "vinyl": "2.1.0"
       },
       "dependencies": {
         "clone": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+          "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
           "dev": true
         },
         "clone-stats": {
@@ -3943,7 +3442,7 @@
           "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
           "dev": true,
           "requires": {
-            "clone": "2.1.2",
+            "clone": "2.1.1",
             "clone-buffer": "1.0.0",
             "clone-stats": "1.0.0",
             "cloneable-readable": "1.1.2",
@@ -4001,7 +3500,7 @@
       "integrity": "sha512-lh9HLdb53sC7XIZOYzTXM4lFuXElv3EVkSDhsd7DoJBj7hm+Ni7D3qYbb+Rr8DuM8nRanBvkVO9d7askreXGnQ==",
       "dev": true,
       "requires": {
-        "concat-with-sourcemaps": "1.0.5",
+        "concat-with-sourcemaps": "1.1.0",
         "lodash.template": "4.4.0",
         "through2": "2.0.3"
       },
@@ -4242,9 +3741,9 @@
       }
     },
     "gulp-rename": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz",
-      "integrity": "sha1-OtRCh2PwXidk3sHGfYaNsnVoeBc=",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.3.tgz",
+      "integrity": "sha512-CmdPM0BjJ105QCX1fk+j7NGhiN/1rCl9HLGss+KllBS/tdYadpjTxqdKyh/5fNV+M3yjT1MFz5z93bXdrTyzAw==",
       "dev": true
     },
     "gulp-replace": {
@@ -4266,17 +3765,17 @@
       "requires": {
         "gulplog": "1.0.0",
         "has-gulplog": "0.1.0",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "make-error-cause": "1.2.2",
         "through2": "2.0.3",
-        "uglify-js": "3.3.21",
+        "uglify-js": "3.3.27",
         "vinyl-sourcemaps-apply": "0.2.1"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
           "dev": true
         }
       }
@@ -4375,22 +3874,6 @@
         "sliced": "1.0.1"
       }
     },
-    "har-schema": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
-      "dev": true
-    },
-    "har-validator": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-      "dev": true,
-      "requires": {
-        "ajv": "4.11.8",
-        "har-schema": "1.0.5"
-      }
-    },
     "has": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
@@ -4410,9 +3893,9 @@
       }
     },
     "has-binary2": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.2.tgz",
-      "integrity": "sha1-6D26SfC5vk0CbSc2U1DZ8D9Uvpg=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
+      "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
       "dev": true,
       "requires": {
         "isarray": "2.0.1"
@@ -4436,7 +3919,7 @@
       "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
       "dev": true,
       "requires": {
-        "sparkles": "1.0.0"
+        "sparkles": "1.0.1"
       }
     },
     "has-value": {
@@ -4506,7 +3989,7 @@
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "hash.js": {
@@ -4517,18 +4000,6 @@
       "requires": {
         "inherits": "2.0.3",
         "minimalistic-assert": "1.0.1"
-      }
-    },
-    "hawk": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "dev": true,
-      "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
       }
     },
     "header": {
@@ -4547,12 +4018,6 @@
         "minimalistic-assert": "1.0.1",
         "minimalistic-crypto-utils": "1.0.1"
       }
-    },
-    "hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
     },
     "homedir-polyfill": {
       "version": "1.0.1",
@@ -4576,14 +4041,23 @@
       "dev": true
     },
     "http-errors": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
-      "integrity": "sha1-eIwNLB3iyBuebowBhDtrl+uSB1A=",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
+        "depd": "1.1.2",
         "inherits": "2.0.3",
-        "setprototypeof": "1.0.2",
-        "statuses": "1.3.1"
+        "setprototypeof": "1.1.0",
+        "statuses": "1.5.0"
+      },
+      "dependencies": {
+        "statuses": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+          "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+          "dev": true
+        }
       }
     },
     "http-proxy": {
@@ -4596,17 +4070,6 @@
         "requires-port": "1.0.0"
       }
     },
-    "http-signature": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "0.2.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.1"
-      }
-    },
     "https-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
@@ -4614,9 +4077,9 @@
       "dev": true
     },
     "iconv-lite": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
-      "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "dev": true,
       "requires": {
         "safer-buffer": "2.1.2"
@@ -4629,9 +4092,9 @@
       "dev": true
     },
     "ignore": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
+      "integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg==",
       "dev": true
     },
     "immutable": {
@@ -4698,12 +4161,12 @@
       "dev": true,
       "requires": {
         "ansi-escapes": "3.1.0",
-        "chalk": "2.3.2",
+        "chalk": "2.4.1",
         "cli-cursor": "2.1.0",
         "cli-width": "2.2.0",
         "external-editor": "2.2.0",
         "figures": "2.0.0",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "mute-stream": "0.0.7",
         "run-async": "2.3.0",
         "rx-lite": "4.0.8",
@@ -4729,14 +4192,14 @@
           }
         },
         "chalk": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.1",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "5.3.0"
+            "supports-color": "5.4.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -4746,9 +4209,9 @@
           "dev": true
         },
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
           "dev": true
         },
         "string-width": {
@@ -4771,9 +4234,9 @@
           }
         },
         "supports-color": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
             "has-flag": "3.0.0"
@@ -4782,12 +4245,12 @@
       }
     },
     "insert-module-globals": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.6.tgz",
-      "integrity": "sha512-R3sidKJr3SsggqQQ5cEwQb3pWG8RNx0UnpyeiOSR6jorRIeAOzH2gkTWnNdMnyRiVbjrG047K7UCtlMkQ1Mo9w==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.1.0.tgz",
+      "integrity": "sha512-LbYZdybvKjbbcKLp03lB323Cgc8f0iL0Rjh8U6JZ7K1gZSf7MxQH191iCNUcLX4qIQ6/yWe4Q4ZsQ+opcReNFg==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.2",
+        "JSONStream": "1.3.3",
         "combine-source-map": "0.8.0",
         "concat-stream": "1.6.2",
         "is-buffer": "1.1.6",
@@ -5061,12 +4524,6 @@
       "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
       "dev": true
     },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
-    },
     "is-unc-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
@@ -5116,12 +4573,6 @@
           "dev": true
         }
       }
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
     },
     "istextorbinary": {
       "version": "1.0.2",
@@ -5173,19 +4624,6 @@
         "esprima": "4.0.0"
       }
     },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true,
-      "optional": true
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true
-    },
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
@@ -5193,9 +4631,9 @@
       "dev": true
     },
     "json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+      "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
       "dev": true,
       "requires": {
         "jsonify": "0.0.0"
@@ -5205,12 +4643,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-      "dev": true
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
     "jsonfile": {
@@ -5233,26 +4665,6 @@
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
-    },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
-      }
     },
     "kind-of": {
       "version": "3.2.2",
@@ -5327,9 +4739,9 @@
       }
     },
     "limiter": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.2.tgz",
-      "integrity": "sha512-JIKZ0xb6fZZYa3deZ0BgXCgX6HgV8Nx3mFGeFHmFWW8Fb2c08e0CyE+G3nalpD0xGvGssjGb1UdFr+PprxZEbw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.3.tgz",
+      "integrity": "sha512-zrycnIMsLw/3ZxTbW7HCez56rcFGecWTx5OZNplzcXUUmJLmoYArC6qdJzmAN5BWiNXGcpjhF9RQ1HSv5zebEw==",
       "dev": true
     },
     "load-json-file": {
@@ -5346,15 +4758,15 @@
       }
     },
     "localtunnel": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.8.3.tgz",
-      "integrity": "sha1-3MWSL9hWUQN9S94k/ZMkjQsk6wU=",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.9.0.tgz",
+      "integrity": "sha512-wCIiIHJ8kKIcWkTQE3m1VRABvsH2ZuOkiOpZUofUCf6Q42v3VIZ+Q0YfX1Z4sYDRj0muiKL1bLvz1FeoxsPO0w==",
       "dev": true,
       "requires": {
+        "axios": "0.17.1",
         "debug": "2.6.8",
         "openurl": "1.1.1",
-        "request": "2.81.0",
-        "yargs": "3.29.0"
+        "yargs": "6.6.0"
       },
       "dependencies": {
         "debug": {
@@ -5367,17 +4779,24 @@
           }
         },
         "yargs": {
-          "version": "3.29.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.29.0.tgz",
-          "integrity": "sha1-GquWYOrnnYuPZ1vK7qtu40ws9pw=",
+          "version": "6.6.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+          "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
           "dev": true,
           "requires": {
-            "camelcase": "1.2.1",
+            "camelcase": "3.0.0",
             "cliui": "3.2.0",
             "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
             "os-locale": "1.4.0",
-            "window-size": "0.1.4",
-            "y18n": "3.2.1"
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "4.2.1"
           }
         }
       }
@@ -5583,6 +5002,12 @@
       "resolved": "https://registry.npmjs.org/match-point/-/match-point-1.0.0.tgz",
       "integrity": "sha512-4i7b7ntLiBw70eFkGRB2PGSuJhtvZmM4anfuf1GTmH43Z5qG+wxhz0vaEHx9CIWygNGuXzrUJORIVGleYtpV2g=="
     },
+    "math-random": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
+      "dev": true
+    },
     "md5.js": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
@@ -5625,9 +5050,9 @@
       }
     },
     "mime": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-      "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
       "dev": true
     },
     "mime-db": {
@@ -5795,7 +5220,7 @@
       "integrity": "sha512-sigq/hm/L+Z5IGi1DDl0x2ptkw7S86aFh213QhPLD8v9Opv90IHzKIuWJrRa5bJ77DVKHco2CfIEuThcT/vDJA==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.2",
+        "JSONStream": "1.3.3",
         "browser-resolve": "1.11.2",
         "cached-path-relative": "1.0.1",
         "concat-stream": "1.6.2",
@@ -5906,9 +5331,9 @@
       }
     },
     "natives": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.3.tgz",
-      "integrity": "sha512-BZGSYV4YOLxzoTK73l0/s/0sH9l8SHs2ocReMH1f8JYSh5FUWu4ZrKCpJdRkWXV6HFR/pZDz7bwWOVAY07q77g==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.4.tgz",
+      "integrity": "sha512-Q29yeg9aFKwhLVdkTAejM/HvYG0Y1Am1+HUkFQGn5k2j8GS+v60TVmZh6nujpEAj/qql+wGUrlryO8bF+b1jEg==",
       "dev": true
     },
     "natural-compare": {
@@ -5948,12 +5373,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
-    },
-    "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
       "dev": true
     },
     "object-assign": {
@@ -6234,7 +5653,7 @@
         "browserify-aes": "1.2.0",
         "create-hash": "1.2.0",
         "evp_bytestokey": "1.0.3",
-        "pbkdf2": "3.0.14"
+        "pbkdf2": "3.0.16"
       }
     },
     "parse-filepath": {
@@ -6380,15 +5799,15 @@
       }
     },
     "pbkdf2": {
-      "version": "3.0.14",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
-      "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.16.tgz",
+      "integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
       "dev": true,
       "requires": {
         "create-hash": "1.2.0",
         "create-hmac": "1.1.7",
-        "ripemd160": "2.0.1",
-        "safe-buffer": "5.1.1",
+        "ripemd160": "2.0.2",
+        "safe-buffer": "5.1.2",
         "sha.js": "2.4.11"
       }
     },
@@ -6396,12 +5815,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/pedding/-/pedding-1.0.0.tgz",
       "integrity": "sha1-f1CY1gMHtO9yQMPWk8sgqUc8YHQ=",
-      "dev": true
-    },
-    "performance-now": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
       "dev": true
     },
     "pify": {
@@ -6538,9 +5951,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
-      "integrity": "sha1-zgPF/wk1vB2daanxTL0Y5WjWdiU=",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
+      "integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4=",
       "dev": true
     },
     "querystring": {
@@ -6556,43 +5969,27 @@
       "dev": true
     },
     "randomatic": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
+      "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "4.0.0",
+        "kind-of": "6.0.2",
+        "math-random": "1.0.1"
       },
       "dependencies": {
         "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
         },
         "kind-of": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "1.1.6"
-          }
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
         }
       }
     },
@@ -6602,7 +5999,7 @@
       "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "randomfill": {
@@ -6612,7 +6009,7 @@
       "dev": true,
       "requires": {
         "randombytes": "2.0.6",
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "range-parser": {
@@ -6620,6 +6017,18 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
       "dev": true
+    },
+    "raw-body": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+      "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+      "dev": true,
+      "requires": {
+        "bytes": "3.0.0",
+        "http-errors": "1.6.3",
+        "iconv-lite": "0.4.23",
+        "unpipe": "1.0.0"
+      }
     },
     "read-only-stream": {
       "version": "2.0.0",
@@ -6661,7 +6070,7 @@
         "inherits": "2.0.3",
         "isarray": "1.0.0",
         "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.1",
+        "safe-buffer": "5.1.2",
         "string_decoder": "1.1.1",
         "util-deprecate": "1.0.2"
       },
@@ -6760,44 +6169,6 @@
         "readable-stream": "2.3.6"
       }
     },
-    "request": {
-      "version": "2.81.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-      "dev": true,
-      "requires": {
-        "aws-sign2": "0.6.0",
-        "aws4": "1.7.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.1.4",
-        "har-validator": "4.2.1",
-        "hawk": "3.1.3",
-        "http-signature": "1.1.1",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.18",
-        "oauth-sign": "0.8.2",
-        "performance-now": "0.2.0",
-        "qs": "6.4.0",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.4",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.2.1"
-      },
-      "dependencies": {
-        "qs": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-          "dev": true
-        }
-      }
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -6893,24 +6264,13 @@
       }
     },
     "ripemd160": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
-      "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "dev": true,
       "requires": {
-        "hash-base": "2.0.2",
+        "hash-base": "3.0.4",
         "inherits": "2.0.3"
-      },
-      "dependencies": {
-        "hash-base": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
-          "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        }
       }
     },
     "run-async": {
@@ -6954,9 +6314,9 @@
       }
     },
     "safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
     "safe-regex": {
@@ -6981,79 +6341,30 @@
       "dev": true
     },
     "send": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.15.2.tgz",
-      "integrity": "sha1-+R+rRAO8+H5xb3DOtdsvV4vcF9Y=",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
       "dev": true,
       "requires": {
-        "debug": "2.6.4",
+        "debug": "2.6.9",
         "depd": "1.1.2",
         "destroy": "1.0.4",
         "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "etag": "1.8.1",
-        "fresh": "0.5.0",
+        "fresh": "0.5.2",
         "http-errors": "1.6.3",
-        "mime": "1.3.4",
-        "ms": "1.0.0",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
         "on-finished": "2.3.0",
         "range-parser": "1.2.0",
-        "statuses": "1.3.1"
+        "statuses": "1.4.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
-          "integrity": "sha1-dYaps8OXQcAoKuM0RcTorHRzT+A=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.3"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "0.7.3",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
-              "integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8=",
-              "dev": true
-            }
-          }
-        },
-        "fresh": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
-          "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44=",
-          "dev": true
-        },
-        "http-errors": {
-          "version": "1.6.3",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-          "dev": true,
-          "requires": {
-            "depd": "1.1.2",
-            "inherits": "2.0.3",
-            "setprototypeof": "1.1.0",
-            "statuses": "1.5.0"
-          },
-          "dependencies": {
-            "statuses": {
-              "version": "1.5.0",
-              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-              "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-              "dev": true
-            }
-          }
-        },
-        "ms": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-1.0.0.tgz",
-          "integrity": "sha1-Wa3NIu3FQ/e1OBhi0xOHsfS8lHM=",
-          "dev": true
-        },
-        "setprototypeof": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+        "statuses": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
           "dev": true
         }
       }
@@ -7088,24 +6399,41 @@
             "ms": "0.7.1"
           }
         },
+        "http-errors": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
+          "integrity": "sha1-eIwNLB3iyBuebowBhDtrl+uSB1A=",
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "setprototypeof": "1.0.2",
+            "statuses": "1.3.1"
+          }
+        },
         "ms": {
           "version": "0.7.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
           "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
           "dev": true
+        },
+        "setprototypeof": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
+          "integrity": "sha1-gaVSFB7BBLiOic44MQOtXGZWTQg=",
+          "dev": true
         }
       }
     },
     "serve-static": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.2.tgz",
-      "integrity": "sha1-5UbicmCBuBtLzsjpCAjrzdMjr7o=",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "dev": true,
       "requires": {
         "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "parseurl": "1.3.2",
-        "send": "0.15.2"
+        "send": "0.16.2"
       }
     },
     "server-destroy": {
@@ -7150,9 +6478,9 @@
       }
     },
     "setprototypeof": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
-      "integrity": "sha1-gaVSFB7BBLiOic44MQOtXGZWTQg=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
       "dev": true
     },
     "sha.js": {
@@ -7162,7 +6490,7 @@
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "shasum": {
@@ -7173,17 +6501,6 @@
       "requires": {
         "json-stable-stringify": "0.0.1",
         "sha.js": "2.4.11"
-      },
-      "dependencies": {
-        "json-stable-stringify": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
-          "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
-          "dev": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          }
-        }
       }
     },
     "shebang-command": {
@@ -7260,7 +6577,7 @@
         "extend-shallow": "2.0.1",
         "map-cache": "0.2.2",
         "source-map": "0.5.7",
-        "source-map-resolve": "0.5.1",
+        "source-map-resolve": "0.5.2",
         "use": "3.1.0"
       },
       "dependencies": {
@@ -7356,15 +6673,6 @@
         "kind-of": "3.2.2"
       }
     },
-    "sntp": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true,
-      "requires": {
-        "hoek": "2.16.3"
-      }
-    },
     "socket.io": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.0.4.tgz",
@@ -7413,7 +6721,7 @@
       "requires": {
         "component-emitter": "1.2.1",
         "debug": "3.1.0",
-        "has-binary2": "1.0.2",
+        "has-binary2": "1.0.3",
         "isarray": "2.0.1"
       },
       "dependencies": {
@@ -7435,12 +6743,12 @@
       "dev": true
     },
     "source-map-resolve": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
-      "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "dev": true,
       "requires": {
-        "atob": "2.1.0",
+        "atob": "2.1.1",
         "decode-uri-component": "0.2.0",
         "resolve-url": "0.2.1",
         "source-map-url": "0.4.0",
@@ -7454,9 +6762,9 @@
       "dev": true
     },
     "sparkles": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
-      "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
+      "integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==",
       "dev": true
     },
     "sparse-boolean-array": {
@@ -7519,30 +6827,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
-    },
-    "sshpk": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
-      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
-      "dev": true,
-      "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
-      }
     },
     "starlog": {
       "version": "1.0.0",
@@ -7615,9 +6899,9 @@
       "dev": true
     },
     "stream-http": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.1.tgz",
-      "integrity": "sha512-cQ0jo17BLca2r0GfRdZKYAGLU6JRoIWxqSOakUMuKOT6MOK7AAlE856L33QuDmAy/eeOrhLee3dZKX0Uadu93A==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.2.tgz",
+      "integrity": "sha512-QllfrBhqF1DPcz46WxKTs6Mz1Bpc+8Qm6vbqOpVav5odAXwbyzwnEczoWqtxrsmlO+cJqtPrp/8gWKWjaKLLlA==",
       "dev": true,
       "requires": {
         "builtin-status-codes": "3.0.0",
@@ -7644,7 +6928,7 @@
       "dev": true,
       "requires": {
         "commander": "2.15.1",
-        "limiter": "1.1.2"
+        "limiter": "1.1.3"
       }
     },
     "string-width": {
@@ -7664,14 +6948,8 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
-    },
-    "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-      "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -7734,24 +7012,12 @@
       "requires": {
         "ajv": "5.5.2",
         "ajv-keywords": "2.1.1",
-        "chalk": "2.3.2",
-        "lodash": "4.17.5",
+        "chalk": "2.4.1",
+        "lodash": "4.17.10",
         "slice-ansi": "1.0.0",
         "string-width": "2.1.1"
       },
       "dependencies": {
-        "ajv": {
-          "version": "5.5.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-          "dev": true,
-          "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.1.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
-          }
-        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -7768,14 +7034,14 @@
           }
         },
         "chalk": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.1",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "5.3.0"
+            "supports-color": "5.4.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -7785,9 +7051,9 @@
           "dev": true
         },
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
           "dev": true
         },
         "string-width": {
@@ -7810,9 +7076,9 @@
           }
         },
         "supports-color": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
             "has-flag": "3.0.0"
@@ -7969,36 +7235,11 @@
         }
       }
     },
-    "tough-cookie": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-      "dev": true,
-      "requires": {
-        "punycode": "1.4.1"
-      }
-    },
     "tty-browserify": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
       "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
       "dev": true
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true,
-      "optional": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -8021,15 +7262,15 @@
       "dev": true
     },
     "ua-parser-js": {
-      "version": "0.7.12",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.12.tgz",
-      "integrity": "sha1-BMgamb3V3FImPqKdJMa/jUgYpLs=",
+      "version": "0.7.17",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
+      "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g==",
       "dev": true
     },
     "uglify-js": {
-      "version": "3.3.21",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.21.tgz",
-      "integrity": "sha512-uy82472lH8tshK3jS3c5IFb5MmNKd/5qyBd0ih8sM42L3jWvxnE339U9gZU1zufnLVs98Stib9twq8dLm2XYCA==",
+      "version": "3.3.27",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.27.tgz",
+      "integrity": "sha512-O94wxMSb3td/TlofkITYvYIlvIVdldvNXDVRekzK13CQZuL37ua4nrdXX0Ro7MapfUVzglRHs0/+imPRUdOghg==",
       "dev": true,
       "requires": {
         "commander": "2.15.1",
@@ -8243,12 +7484,6 @@
       "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=",
       "dev": true
     },
-    "uuid": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
-      "dev": true
-    },
     "uws": {
       "version": "9.14.0",
       "resolved": "https://registry.npmjs.org/uws/-/uws-9.14.0.tgz",
@@ -8273,25 +7508,6 @@
       "requires": {
         "spdx-correct": "3.0.0",
         "spdx-expression-parse": "3.0.0"
-      }
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
       }
     },
     "vinyl": {
@@ -8343,7 +7559,7 @@
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
           "dev": true,
           "requires": {
-            "natives": "1.1.3"
+            "natives": "1.1.4"
           }
         },
         "isarray": {
@@ -8413,9 +7629,9 @@
       },
       "dependencies": {
         "clone": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+          "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
           "dev": true
         },
         "clone-stats": {
@@ -8436,7 +7652,7 @@
           "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
           "dev": true,
           "requires": {
-            "clone": "2.1.2",
+            "clone": "2.1.1",
             "clone-buffer": "1.0.0",
             "clone-stats": "1.0.0",
             "cloneable-readable": "1.1.2",
@@ -8480,9 +7696,9 @@
       "dev": true
     },
     "window-size": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+      "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
       "dev": true
     },
     "wordwrap": {
@@ -8523,7 +7739,7 @@
       "dev": true,
       "requires": {
         "async-limiter": "1.0.0",
-        "safe-buffer": "5.1.1",
+        "safe-buffer": "5.1.2",
         "ultron": "1.1.1"
       }
     },
@@ -8571,20 +7787,6 @@
         "window-size": "0.2.0",
         "y18n": "3.2.1",
         "yargs-parser": "4.2.1"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-          "dev": true
-        },
-        "window-size": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-          "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
-          "dev": true
-        }
       }
     },
     "yargs-parser": {
@@ -8594,14 +7796,6 @@
       "dev": true,
       "requires": {
         "camelcase": "3.0.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-          "dev": true
-        }
       }
     },
     "yeast": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "extend-me": "^2.7.0",
     "fin-hypergrid-data-source-base": "^0.4.10",
     "fin-hypergrid-event-logger": "^1.0.3",
-    "finbars": "1.5.2",
+    "finbars": "^1.6.0",
     "inject-stylesheet-template": "^1.0.1",
     "mustache": "^2.3.0",
     "object-iterators": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fin-hypergrid",
-  "version": "2.1.10",
+  "version": "2.1.11",
   "description": "Canvas-based high-performance grid",
   "repository": {
     "type": "git",

--- a/src/Hypergrid.js
+++ b/src/Hypergrid.js
@@ -1322,10 +1322,6 @@ var Hypergrid = Base.extend('Hypergrid', {
         return this.behavior.getHiddenColumns();
     },
 
-    isViewableButton: function(c, r) {
-        return this.renderer.isViewableButton(c, r);
-    },
-
     /**
      * @memberOf Hypergrid#
      * @desc Request input focus.

--- a/src/Hypergrid.js
+++ b/src/Hypergrid.js
@@ -1227,7 +1227,7 @@ var Hypergrid = Base.extend('Hypergrid', {
      */
     insureModelRowIsVisible: function(rowIndex, offsetY) {
         var maxRows = this.getRowCount() - 1, // -1 excludes partially visible rows
-            scrollOffset = (offsetY > -1) ? 2 : 0, // 2 to keep one blank line below active cell, 0 to keep zero lines above active cell
+            scrollOffset = (offsetY > -1) ? 1 : 0, // 1 to keep one blank line below active cell, 0 to keep zero lines above active cell
             indexToCheck = rowIndex + scrollOffset,
             visible = !this.isDataRowVisible(indexToCheck) || rowIndex === maxRows;
 

--- a/src/cellEditors/CellEditor.js
+++ b/src/cellEditors/CellEditor.js
@@ -134,6 +134,7 @@ var CellEditor = Base.extend('CellEditor', {
                     alt: e.altKey,
                     ctrl: e.ctrlKey,
                     char: keyChar,
+                    legacyChar: e.legacyKey, // decorated by getKeyChar
                     code: e.charCode,
                     key: e.keyCode,
                     meta: e.metaKey,

--- a/src/cellEditors/CellEditor.js
+++ b/src/cellEditors/CellEditor.js
@@ -249,17 +249,13 @@ var CellEditor = Base.extend('CellEditor', {
     stopEditing: function(feedback) {
         var str = this.input.value;
 
-        /**
-         * @type {boolean|string|Error}
-         */
-        var error = this.validateEditorValue(str);
-
-        if (!error) {
-            try {
+        try {
+            var error = this.validateEditorValue(str);
+            if (!error) {
                 var value = this.getEditorValue(str);
-            } catch (err) {
-                error = err;
             }
+        } catch (err) {
+            error = err;
         }
 
         if (!error && this.grid.fireSyntheticEditorDataChangeEvent(this, this.initialValue, value)) {
@@ -382,6 +378,7 @@ var CellEditor = Base.extend('CellEditor', {
      * Override this method if your editor has additional or alternative GUI elements. The GUI elements will influence the primitive value, either by altering the edited string before it is parsed, or by transforming the parsed value before returning it.
      * @param {string} str - current editors input string
      * @returns {object} the current editor's value
+     * @throws {boolean|string|Error} Throws an error on parse failure. If the error's `message` is defined, the message will eventually be displayed (every `feedbackCount`th attempt).
      * @memberOf CellEditor.prototype
      */
     getEditorValue: function(str) {
@@ -392,6 +389,8 @@ var CellEditor = Base.extend('CellEditor', {
      * If there is no validator on the localizer, returns falsy (not invalid; possibly valid).
      * @param {string} str - current editors input string
      * @returns {boolean|string} Truthy value means invalid. If a string, this will be an error message. If not a string, it merely indicates a generic invalid result.
+     * @throws {boolean|string|Error} May throw an error on syntax failure as an alternative to returning truthy. Define the error's `message` field as an alternative to returning string.
+     * @memberOf CellEditor.prototype
      */
     validateEditorValue: function(str) {
         return this.localizer.invalid && this.localizer.invalid(str);

--- a/src/cellEditors/CellEditor.js
+++ b/src/cellEditors/CellEditor.js
@@ -247,14 +247,16 @@ var CellEditor = Base.extend('CellEditor', {
      * @memberOf CellEditor.prototype
      */
     stopEditing: function(feedback) {
+        var str = this.input.value;
+
         /**
          * @type {boolean|string|Error}
          */
-        var error = this.validateEditorValue();
+        var error = this.validateEditorValue(str);
 
         if (!error) {
             try {
-                var value = this.getEditorValue();
+                var value = this.getEditorValue(str);
             } catch (err) {
                 error = err;
             }
@@ -378,19 +380,21 @@ var CellEditor = Base.extend('CellEditor', {
      * The localizer's {@link localizerInterface#parse|parse} method will be called on the text box contents.
      *
      * Override this method if your editor has additional or alternative GUI elements. The GUI elements will influence the primitive value, either by altering the edited string before it is parsed, or by transforming the parsed value before returning it.
+     * @param {string} str - current editors input string
      * @returns {object} the current editor's value
      * @memberOf CellEditor.prototype
      */
-    getEditorValue: function() {
-        return this.localizer.parse(this.input.value);
+    getEditorValue: function(str) {
+        return this.localizer.parse(str);
     },
 
     /**
      * If there is no validator on the localizer, returns falsy (not invalid; possibly valid).
+     * @param {string} str - current editors input string
      * @returns {boolean|string} Truthy value means invalid. If a string, this will be an error message. If not a string, it merely indicates a generic invalid result.
      */
-    validateEditorValue: function() {
-        return this.localizer.invalid && this.localizer.invalid(this.input.value);
+    validateEditorValue: function(str) {
+        return this.localizer.invalid && this.localizer.invalid(str);
     },
 
     /**

--- a/src/cellEditors/CellEditor.js
+++ b/src/cellEditors/CellEditor.js
@@ -299,15 +299,17 @@ var CellEditor = Base.extend('CellEditor', {
      * @memberOf CellEditor.prototype
      */
     errorEffectBegin: function(error) {
-        var spec = this.grid.properties.feedbackEffect, // spec may e a string or an object with name and options props
-            options = Object.assign({}, spec.options), // if spec is a string, spec.options will be undefined
-            effect = effects[spec.name || spec]; // if spec is a string, spec.name will be undefined
-
-        if (error) {
-            options.callback = this.errorEffectEnd.bind(this, error);
+        if (this.effecting) {
+            return;
         }
 
+        var spec = this.grid.properties.feedbackEffect, // spec may e a string or an object with name and options props
+            effect = effects[spec.name || spec]; // if spec is a string, spec.name will be undefined
+
         if (effect) {
+            var options = Object.assign({}, spec.options); // if spec is a string, spec.options will be undefined
+            options.callback = this.errorEffectEnd.bind(this, error);
+            this.effecting = true;
             effect.call(this, options);
         }
     },
@@ -347,6 +349,7 @@ var CellEditor = Base.extend('CellEditor', {
                 alert(msg); // eslint-disable-line no-alert
             });
         }
+        this.effecting = false;
     },
 
     /**

--- a/src/cellEditors/CellEditor.js
+++ b/src/cellEditors/CellEditor.js
@@ -10,15 +10,13 @@ var Localization = require('../lib/Localization');
 
 /**
  * @constructor
+ * @param grid
+ * @param {CellEvent} options - Properties listed below + arbitrary mustache "variables" for merging into template.
+ * @param {Point} options.editPoint - Deprecated; use `options.gridCell`.
+ * @param {string} [options.format] - Name of a localizer with which to override prototype's `localizer` property.
  */
 var CellEditor = Base.extend('CellEditor', {
 
-    /**
-     * @param grid
-     * @param {CellEvent} options - Properties listed below + arbitrary mustache "variables" for merging into template.
-     * @param {Point} options.editPoint - Deprecated; use `options.gridCell`.
-     * @param {string} [options.format] - Name of a localizer with which to override prototype's `localizer` property.
-     */
     initialize: function(grid, options) {
         // Mix in all enumerable properties for mustache use, typically `column` and `format`.
         for (var key in options) {

--- a/src/cellEditors/Textfield.js
+++ b/src/cellEditors/Textfield.js
@@ -16,6 +16,7 @@ var Textfield = CellEditor.extend('Textfield', {
 
     initialize: function() {
         this.input.style.textAlign = this.event.properties.halign;
+        this.input.style.font = this.event.properties.font;
     },
 
     localizer: Localization.prototype.string,

--- a/src/cellRenderers/Button.js
+++ b/src/cellRenderers/Button.js
@@ -15,8 +15,6 @@ var Button = CellRenderer.extend('Button', {
      */
     paint: function(gc, config) {
         var val = config.value,
-            c = config.dataCell.x,
-            r = config.gridCell.y,
             bounds = config.bounds,
             x = bounds.x + 1,
             y = bounds.y + 1,
@@ -56,9 +54,6 @@ var Button = CellRenderer.extend('Button', {
         gc.cache.font = height - 2 + 'px sans-serif';
         config.backgroundColor = 'rgba(0,0,0,0)';
         gc.fillText(val, x + ox, y + oy);
-
-        //identify that we are a button
-        config.buttonCells[c + ',' + r] = true;
     }
 });
 

--- a/src/cellRenderers/CellRenderer.js
+++ b/src/cellRenderers/CellRenderer.js
@@ -1,5 +1,83 @@
 'use strict';
 
+/** @typedef {object} CellRenderer#renderConfig
+ * This is the renderer config object, which is:
+ * 1. First passed to a {@link DataModel#getCell getCell} method implementation, which may override (most of) its values before returning.
+ * 2. Then passed to the specified cell renderers' {@link CellRenderer#paint paint} function for rendering.
+ *
+ * #### Standard Properties
+ *
+ * On each render of every visible cell, this a fresh instance of an object created from (whose prototype is) a properties object as defined by layer-props.js. It therefore has all the standard properties defined in {@link module:defaults}.
+ *
+ * #### Additional Properties
+ *
+ * In addition, the config object has the following additional properties.
+ *
+ * Properties marked **_read-only_** may in fact be writable, but should be considered **off limits** to overriding. Do not attempt to change these properties inside a {@link DataModel#getCell getCell} method override.
+ *
+ * Properties marked **_write-only_** are to be defined the cell renderer for use by the caller (the grid renderer).
+ *
+ * @property {boolean} config.allRowsSelected
+ *
+ * @property {BoundingRect} config.bounds - Bounding rect of the cell or subcell to be rendered.
+ *
+ * @property {object} [config.clickRect] - **_Write-only._** The Cell renderer may return in this property a subrect in the cell's local coordinates that represents a click region. If defined by the cell renderer, the CellClick feature will ignore clicks outside the click region. If not defined by the cell renderer, the entire cell is clickable.
+ *
+ * @property {dataCellCoords} config.dataCell - **_Read-only._** Data coordinates of the cell.
+ *
+ * @property {dataRowObject} config.dataRow - Access to other column values in the same row.
+ *
+ * @property {function} config.formatValue - _For cell renderer use only. Not available in `getCell` override._ The cell's value formatter function (based on the formatter name in `config.format`, as possibly mutated by `getCell`).
+ *
+ * @property {gridCellCoords} config.gridCell - **_Read-only._** Grid coordinates of the cell.
+ *
+ * @property {string} config.halign - The cell's horizontal alignment property, as interpreted by it's cell renderer.
+ *
+ * @property {boolean} config.isCellHovered -
+ *
+ * @property {boolean} config.isCellSelected -
+ *
+ * @property {boolean} config.isColumnHovered -
+ *
+ * @property {boolean} config.isColumnSelected -
+ *
+ * @property {boolean} config.isDataColumn -
+ *
+ * @property {boolean} config.isDataRow -
+ *
+ * @property {boolean} config.isFilterRow -
+ *
+ * @property {boolean} config.isHandleColumn -
+ *
+ * @property {boolean} config.isHeaderRow -
+ *
+ * @property {boolean} config.isInCurrentSelectionRectangle -
+ *
+ * @property {boolean} config.isRowHovered -
+ *
+ * @property {boolean} config.isRowSelected -
+ *
+ * @property {boolean} config.isSelected -
+ *
+ * @property {boolean} config.isTreeColumn -
+ *
+ * @property {boolean} config.isUserDataArea -
+ *
+ * @property {number} config.minWidth - **_Write-only._** The Cell renderer should return the pixel width of the rendered contents in this property.
+ *
+ * @property {boolean} config.mouseDown - The last mousedown event occurred over this cell and the mouse is still down. Note, however, that the mouse may no longer be hovering over this cell when it has been dragged away.
+ *
+ * @property {} [config.prefillColor] - **_Write-only._** This is the color _already painted_ by the grid renderer behind the cell to be rendered. If the cell's specified background color is the same, renderer may (and should!) skip painting it. If `undefined`, this signals a "partial render"; cell renderers that support partial rendering can use `config.snapshot` to determine whether or not to rerender the cell.
+ *
+ * @property {object} [config.snapshot] - **_Write-only._** Supports _partial render._ In support of the {@link Renderer#paintCellsAsNeeded by-cells} "partial" grid renderer, cell renderers can save the essential render parameters in this property so that on subsequent calls, when the parameters are the same, cell renderers can skip the actual rendering. Only when the parameters have changed is the cell rendered and this property reset (with the new parameters). This object would typically include at the very least the (formatted) `value`, plus additional properties as needed to fully describe the appearance of the render, such as color, _etc._ This property is undefined the first time a cell is rendered by the `by-cells` grid renderer. See also the {@link DataModel#configObject}'s `prefillColor` property.
+ *
+ * @property config.value - Value to be rendered.
+ *
+ * The renderer has available to it the `.formatValue()` function for formatting the value. The function comes from the localizer named in the `.format` property. If there is no localizer with that name, the function defaults to the `string` localizer's formatter (which simply invokes the value's `toString()` method).
+ *
+ * Typically a Local primitive value, values can be any type, including objects and arrays. The specified cell renderer is expected to know how to determine the value's type and render it.
+*/
+
 var Base = require('../Base');
 
 /** @typedef paintFunction

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1195,6 +1195,14 @@ var defaults = {
      */
     autoSelectColumns: false,
 
+    /**
+     * Collapse cell selection onto next row selection.
+     * @default
+     * @type {boolean}
+     * @memberOf module:defaults
+     */
+    collapseCellSelections: false,
+
     /** @summary Name of a formatter for cell text.
      * @desc Unknown formatter falls back to the `string` formatter (simple conversion to string with `+ ''`).
      * @default undefined

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -52,6 +52,49 @@ var defaults = {
     noDataMessage: '',
 
     /**
+     * Multiplier for horizontal mouse wheel movement, applied to values of [`WheelEvent#deltaX`](https://developer.mozilla.org/docs/Web/API/WheelEvent/deltaX) (received by the horizontal scrollbar's listener).
+     *
+     * #### Caveat
+     * Wheel granularity depends on the OS, the input device, and possibly the browser. Any setting you choose will work differently in different environments. If you don't know the user's environment, it is probably best to give users control of this setting so they can fine tune it themselves.
+     *
+     * #### Default values
+     * This particular default value of `0.01` seems to work well on the MacBook Pro trackpad. It's slower than it was, which will greatly improve the scrolling experience since column scrolling often occurred inadvertently when the intent was to scroll in the veritcal direction only.
+     *
+     * Be aware however that the trackpad scrolling speed can be adjusted by the Mac user at the OS level (System Preferences -> Accessibility -> Mouse & Trackpad -> Trackpad Options… -> Scrolling speed).
+     *
+     * Hint: You can tell if the user is using a trackpad by listening for any deltaX (since a simple mouse wheel is deltaY only); and what OS by checking user agent.
+     * @default
+     * @type {number}
+     * @memberOf module:defaults
+     */
+    wheelHFactor: 0.01,
+
+    /**
+     * Multiplier for vertical mouse wheel movement, applied to values of [`WheelEvent#deltaY`](https://developer.mozilla.org/docs/Web/API/WheelEvent/deltaY) (received by the vertical scrollbar's listener).
+     *
+     * #### Caveat
+     * Wheel granularity depends on the OS, the input device, and possibly the browser. Any setting you choose will work differently in different environments. If you don't know the user's environment, it is probably best to give users control of this setting so they can fine tune it themselves.
+     *
+     * #### Default values
+     * This particular default value of `0.05` is a compromise. It seems to work well on the MacBook Pro trackpad; and works acceptably (though differently) with a mouse wheel on both Mac OS and Windows.
+     *
+     * Be aware however that the trackpad scrolling speed can be adjusted by the Mac user at the OS level (System Preferences -> Accessibility -> Mouse & Trackpad -> Trackpad Options… -> Scrolling speed). Mouse wheel scrolling speed is also adjustable ( _yada yada_ -> Mouse Options… -> Scrolling speed; or on Windows search for "Change mouse wheel settings" in the Start menu).
+     *
+     * This default setting of `0.05` feels good on trackpad (2-finger drag). It's much slower than it was, but the way it was before was way to coarse and fast, scrolling hundreds of rows in a flash.
+     *
+     * With this setting, a mouse connected to a Mac, the wheel requires 5 click-stops to scroll 1 row; the same mouse connected to Windows scrolls 5 rows per click-stop. (However, I may have changed the default settings on my machines; not sure.)
+     *
+     * On Windows, the original multiplier setting (_i.e.,_ `1.0`) scrolled 100 grid rows on a single mouse wheel click-stop; the new default (`0.05`) scrolls 5 rows per click-stop. It stands to reason therefore that a setting of `0.01` will scroll 1:1 (1 row per 1 click-stop).
+     *
+     #### Hint
+     You can tell if the user is using a trackpad by listening for any deltaX (since a simple mouse wheel is deltaY only); and what OS by checking user agent.
+     * @default
+     * @type {number}
+     * @memberOf module:defaults
+     */
+    wheelVFactor: 0.05,
+
+    /**
      * @summary List of subgrids by
      * @desc Restrict usage here to strings (naming data models) or arrays consisting of such a string + constructor arguments. That is, avoid {@link subgridSpec}'s function and object overloads and {@link subgridConstructorRef} function overload.
      * @default "[ 'HeaderSubgrid', 'data' ]"

--- a/src/features/ColumnSelection.js
+++ b/src/features/ColumnSelection.js
@@ -78,9 +78,11 @@ var ColumnSelection = Feature.extend('ColumnSelection', {
         // todo: >= 5 depends on header being top-most row which is currently always true but we may allow header "section" to be arbitrary position within quadrant (see also handleMouseDown in ColumnMoving.js)
         if (
             grid.properties.columnSelection &&
-            event.mousePoint.y >= 5 &&
             !event.primitiveEvent.detail.isRightClick &&
-            event.isHeaderCell
+            (
+                grid.properties.autoSelectColumns ||
+                event.isHeaderCell && event.mousePoint.y >= 5
+            )
         ) {
             // HOLD OFF WHILE WAITING FOR DOUBLE-CLICK
             this.doubleClickTimer = setTimeout(

--- a/src/features/RowSelection.js
+++ b/src/features/RowSelection.js
@@ -67,9 +67,10 @@ var RowSelection = Feature.extend('RowSelection', {
      */
     handleMouseDown: function(grid, event) {
         var rowSelectable = grid.properties.rowSelection &&
-            !event.primitiveEvent.detail.isRightClick &&
-            grid.properties.showRowNumbers &&
-            event.isHandleColumn;
+            !event.primitiveEvent.detail.isRightClick && (
+                grid.properties.autoSelectRows ||
+                grid.properties.showRowNumbers && event.isHandleColumn
+            );
 
         if (rowSelectable && event.isHeaderHandle) {
             //global row selection

--- a/src/jsdoc/interfaces/localization.js
+++ b/src/jsdoc/interfaces/localization.js
@@ -29,7 +29,7 @@
  * @name localizerInterface#parse
  * @param {string} editedValue
  * @returns {null|*} Primitive typed value.
- * @throws {boolean|string|Error} Parser error.
+ * @throws {boolean|string|Error} Throws an error on parse failure. If the error's `message` is defined, the message will eventually be displayed (every `feedbackCount`th attempt).
  */
 
 /**
@@ -37,11 +37,14 @@
  * @summary Tests string representation for invalidity.
  * @desc Implementation of this method is optional.
  *
- * The method may be strict or loose but caller has no way of knowing and must assume loose. Loose means it may return a false negative. This means that while a truthy return means invalid, falsy merely means "not invalid." In other words, you cannot assume that a falsy value means valid. The parser is the final arbiter and should be designed to throw an error on parser jam. For example, a number parser should not simply return NaN but should throw an error.
+ * The method may be strict or loose but caller has no way of knowing and must assume loose. Loose means it may return a false negative. This means that while a truthy return means invalid, falsy merely means "not invalid." The parser is the final arbiter and should throw an error on parser jam.
+ *
+ * Return an error message here only if you can describe what precisely caused the syntax error. If all you know is that there was a syntax error, it would probably be more helpful to the user to define {@link localizerInterface#expectation expectation}, which is appended to all error messages, and should contain a general description of the expected syntax.
  *
  * Overridden by `options.invalid` passed to constructor.
  * @method
  * @returns {boolean|string} Truthy value means invalid. If a string, this will be an error message. If not a string, it merely indicates a generic invalid result.
+ * @throws {boolean|string|Error} May throw an error on syntax failure as an alternative to returning truthy. Define the error's `message` field as an alternative to returning string.
  */
 
 /**

--- a/src/jsdoc/interfaces/misc.js
+++ b/src/jsdoc/interfaces/misc.js
@@ -1,0 +1,7 @@
+/** @typedef BoundingRect
+ * @summary A bounding rectangle.
+ * @property {number} x - Horizontal coordinate of upper-left corner of bounding rect.
+ * @property {number} y - Vertical coordinate of upper-left corner of bounding rect.
+ * @property {number} width - Width of bounding rect.
+ * @property {number} height - Height of bounding rect.
+ */

--- a/src/lib/Canvas.js
+++ b/src/lib/Canvas.js
@@ -431,9 +431,20 @@ Canvas.prototype = {
     },
 
     getKeyChar: function(e) {
-        var key = e.keyCode || e.detail.key,
-            shift = e.shiftKey || e.detail.shift;
-        return charMap[key][shift ? 1 : 0];
+        var keyCode = e.keyCode || e.detail.key,
+            shift = e.shiftKey || e.detail.shift,
+            key = e.key;
+
+        e.legacyKey = charMap[keyCode] && charMap[keyCode][shift ? 1 : 0];
+
+        if (typeof key === 'string' && key.length === 1) {
+            return key;
+        }
+
+        return (
+            e.legacyKey || // legacy unprintable char string
+            key // modern unprintable char string when no such legacy string
+        );
     },
 
     finkeydown: function(e) {
@@ -467,6 +478,7 @@ Canvas.prototype = {
             alt: e.altKey,
             ctrl: e.ctrlKey,
             char: keyChar,
+            legacyChar: e.legacyKey,
             code: e.charCode,
             key: e.keyCode,
             meta: e.metaKey,
@@ -497,6 +509,7 @@ Canvas.prototype = {
             alt: e.altKey,
             ctrl: e.ctrlKey,
             char: keyChar,
+            legacyChar: e.legacyKey,
             code: e.charCode,
             key: e.keyCode,
             meta: e.metaKey,

--- a/src/lib/InclusiveRectangle.js
+++ b/src/lib/InclusiveRectangle.js
@@ -1,0 +1,28 @@
+'use strict';
+
+var Rectangle = require('rectangular').Rectangle;
+
+/*
+ * The Hypergrid selection model defines a rectangle's bottom and right as inclusive rather than exclusive.
+ * This definition works fine so long as it is used consistently. It does however throw off `Rectangle`'s
+ * `width`, `height`, and `area` properties, all of which are getters which assume an exclusive model.
+ * The following `SelectionModel` object extends (subclasses) `Rectangle` to correct this problem so that
+ * those properties return accurate results.
+ */
+function InclusiveRectangle(x, y, width, height) {
+    Rectangle.call(this, x, y, width - 1, height - 1);
+}
+InclusiveRectangle.prototype = Object.create(Rectangle.prototype, {
+    width: {
+        get: function() {
+            return this.extent.x + 1;
+        }
+    },
+    height: {
+        get: function() {
+            return this.extent.y + 1;
+        }
+    }
+});
+
+module.exports = InclusiveRectangle;

--- a/src/lib/SelectionModel.js
+++ b/src/lib/SelectionModel.js
@@ -2,6 +2,8 @@
 
 var RangeSelectionModel = require('sparse-boolean-array');
 
+var InclusiveRectangle = require('./InclusiveRectangle');
+
 /**
  *
  * @constructor
@@ -91,8 +93,8 @@ SelectionModel.prototype = {
      * @memberOf SelectionModel.prototype
      * @returns {*}
      */
-    getLastSelectionType: function() {
-        return this.lastSelectionType[0] || '';
+    getLastSelectionType: function(n) {
+        return this.lastSelectionType[n || 0] || '';
     },
 
     /**
@@ -128,7 +130,7 @@ SelectionModel.prototype = {
      * @param {boolean} silent - whether to fire selection changed event
      */
     select: function(ox, oy, ex, ey, silent) {
-        var newSelection = this.grid.newRectangle(ox, oy, ex, ey);
+        var newSelection = new InclusiveRectangle(ox, oy, ex + 1, ey + 1);
 
         //Cache the first selected cell before it gets normalized to top-left origin
         newSelection.firstSelectedCell = this.grid.newPoint(ox, oy);
@@ -322,6 +324,7 @@ SelectionModel.prototype = {
      *
      */
     clear: function(keepRowSelections) {
+        this.lastSelectionType.length = 0;
         this.selections.length = 0;
         this.flattenedX.length = 0;
         this.flattenedY.length = 0;

--- a/src/lib/SelectionModel.js
+++ b/src/lib/SelectionModel.js
@@ -324,14 +324,16 @@ SelectionModel.prototype = {
      *
      */
     clear: function(keepRowSelections) {
-        this.lastSelectionType.length = 0;
         this.selections.length = 0;
         this.flattenedX.length = 0;
         this.flattenedY.length = 0;
         this.columnSelectionModel.clear();
         if (!keepRowSelections) {
+            this.lastSelectionType.length = 0;
             this.setAllRowsSelected(false);
             this.rowSelectionModel.clear();
+        } else if (this.lastSelectionType.indexOf('row') >= 0) {
+            this.lastSelectionType = ['row'];
         }
         //this.getGrid().selectionChanged();
     },

--- a/src/lib/cellEventFactory.js
+++ b/src/lib/cellEventFactory.js
@@ -464,6 +464,18 @@ factory.cellEventProperties = Object.defineProperties({}, {
     } },
 });
 
+/** @typedef {WritablePoint} dataCellCoords
+ * @property {number} x - The data model's column index, unaffected by column scrolling; _i.e.,_
+ * an index suitable for dereferencing the column object to which the cell belongs via {@link Behavior#getColumn}.
+ * @property {number} y - The data model's row index, adjusted for data row scrolling after fixed rows.
+ */
+
+/** @typedef {WritablePoint} gridCellCoords
+ * @property {number} x - The active column index, adjusted for column scrolling after fixed columns; _i.e.,_
+ * an index suitable for dereferencing the column object to which the cell belongs via {@link Behavior#getActiveColumn}.
+ * @property {number} y - The vertical grid coordinate, unaffected by subgrid, row scrolling, and fixed rows.
+ */
+
 /**
  * @name cellEventFactory
  *

--- a/src/lib/dynamicProperties.js
+++ b/src/lib/dynamicProperties.js
@@ -30,6 +30,26 @@ var dynamicPropertyDescriptors = {
         }
     },
 
+    wheelHFactor: {
+        enumerable: true,
+        get: function() {
+            return this.grid.sbHScroller.deltaXFactor;
+        },
+        set: function(factor) {
+            this.grid.sbHScroller.deltaXFactor = factor;
+        }
+    },
+
+    wheelVFactor: {
+        enumerable: true,
+        get: function() {
+            return this.grid.sbVScroller.deltaYFactor;
+        },
+        set: function(factor) {
+            this.grid.sbVScroller.deltaYFactor = factor;
+        }
+    },
+
     /**
      * @memberOf module:dynamicPropertyDescriptors
      */

--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -120,7 +120,8 @@ module.exports = {
         return dispatchEvent.call(this, 'fin-editor-keyup', {
             input: inputControl,
             keyEvent: keyEvent,
-            char: this.canvas.getCharMap()[keyEvent.keyCode][keyEvent.shiftKey ? 1 : 0]
+            char: this.canvas.getKeyChar(keyEvent),
+            legacyChar: keyEvent.legacyKey // decorated by getKeyChar
         });
     },
 
@@ -128,7 +129,8 @@ module.exports = {
         return dispatchEvent.call(this, 'fin-editor-keydown', {
             input: inputControl,
             keyEvent: keyEvent,
-            char: this.canvas.getCharMap()[keyEvent.keyCode][keyEvent.shiftKey ? 1 : 0]
+            char: this.canvas.getKeyChar(keyEvent),
+            legacyChar: keyEvent.legacyKey // decorated by getKeyChar
         });
     },
 
@@ -136,7 +138,8 @@ module.exports = {
         return dispatchEvent.call(this, 'fin-editor-keypress', {
             input: inputControl,
             keyEvent: keyEvent,
-            char: this.canvas.getCharMap()[keyEvent.keyCode][keyEvent.shiftKey ? 1 : 0]
+            char: this.canvas.getKeyChar(keyEvent),
+            legacyChar: keyEvent.legacyKey // decorated by getKeyChar
         });
     },
 

--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -188,7 +188,7 @@ module.exports = {
     },
 
     fireSyntheticButtonPressedEvent: function(event) {
-        if (this.isViewableButton(event.dataCell.x, event.gridCell.y)) {
+        if (event.properties.renderer === 'button') {
             return dispatchEvent.call(this, 'fin-button-pressed', {}, event);
         }
     },

--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -404,9 +404,19 @@ module.exports = {
                 return;
             }
             handleMouseEvent(e, function(mouseEvent) {
-                mouseEvent.keys = e.detail.keys; // todo: this was in fin-tap but wasn't here
-                this.fireSyntheticClickEvent(mouseEvent);
-                this.delegateClick(mouseEvent);
+                var isMouseDownCell = this.mouseDownState && this.mouseDownState.gridCell.equals(mouseEvent.gridCell);
+                if (
+                    isMouseDownCell &&
+                    isMousePointInClickRect(mouseEvent)
+                ) {
+                    mouseEvent.keys = e.detail.keys; // todo: this was in fin-tap but wasn't here
+                    if (this.mouseDownState) {
+                        this.fireSyntheticButtonPressedEvent(this.mouseDownState);
+                        this.mouseDownState = null;
+                    }
+                    this.fireSyntheticClickEvent(mouseEvent);
+                    this.delegateClick(mouseEvent);
+                }
             });
         });
 
@@ -423,10 +433,6 @@ module.exports = {
             }
             handleMouseEvent(e, function(mouseEvent) {
                 this.delegateMouseUp(mouseEvent);
-                if (self.mouseDownState) {
-                    self.fireSyntheticButtonPressedEvent(self.mouseDownState);
-                }
-                this.mouseDownState = null;
                 this.fireSyntheticMouseUpEvent(mouseEvent);
             });
         });
@@ -590,6 +596,10 @@ module.exports = {
         this.behavior.onKeyUp(this, event);
     },
 };
+
+function isMousePointInClickRect(e) {
+    return !e.clickRect || e.clickRect.contains(e.mousePoint);
+}
 
 var details = [
     'gridCell',

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -2,9 +2,10 @@
 
 module.exports = {
     cellEventFactory: require('./cellEventFactory'),
-    DataSourceOrigin: require('./DataSourceOrigin'),
     dynamicPropertyDescriptors: require('./dynamicProperties'),
+    fields: require('./fields'),
     graphics: require('./graphics'),
     Canvas: require('./Canvas'),
-    fields: require('./fields')
+    DataSourceOrigin: require('./DataSourceOrigin'),
+    InclusiveRectangle: require('./InclusiveRectangle')
 };

--- a/src/lib/scrolling.js
+++ b/src/lib/scrolling.js
@@ -208,12 +208,14 @@ exports.mixin = {
 
         var horzBar = new Scrollbar({
             orientation: 'horizontal',
+            deltaXFactor: this.constructor.defaults.wheelHFactor,
             onchange: self.setHScrollValue.bind(self),
             cssStylesheetReferenceElement: this.div
         });
 
         var vertBar = new Scrollbar({
             orientation: 'vertical',
+            deltaYFactor: this.constructor.defaults.wheelVFactor,
             onchange: self.setVScrollValue.bind(self),
             paging: {
                 up: self.pageUp.bind(self),

--- a/src/lib/selection.js
+++ b/src/lib/selection.js
@@ -42,15 +42,15 @@ module.exports = {
      * @returns {string} Tab separated value string from the selection and our data.
      */
     getSelectionAsTSV: function() {
-        var sm = this.selectionModel;
-        if (sm.hasSelections()) {
-            var selections = this.getSelectionMatrix();
-            selections = selections[selections.length - 1];
-            return this.getMatrixSelectionAsTSV(selections);
-        } else if (sm.hasRowSelections()) {
-            return this.getMatrixSelectionAsTSV(this.getRowSelectionMatrix());
-        } else if (sm.hasColumnSelections()) {
-            return this.getMatrixSelectionAsTSV(this.getColumnSelectionMatrix());
+        switch (this.selectionModel.getLastSelectionType()) {
+            case 'cell':
+                var selections = this.getSelectionMatrix();
+                selections = selections[selections.length - 1];
+                return this.getMatrixSelectionAsTSV(selections);
+            case 'row':
+                return this.getMatrixSelectionAsTSV(this.getRowSelectionMatrix());
+            case 'column':
+                return this.getMatrixSelectionAsTSV(this.getColumnSelectionMatrix());
         }
     },
 
@@ -592,8 +592,8 @@ module.exports = {
     getSelections: function() {
         return this.behavior.getSelections();
     },
-    getLastSelectionType: function() {
-        return this.selectionModel.getLastSelectionType();
+    getLastSelectionType: function(n) {
+        return this.selectionModel.getLastSelectionType(n);
     },
     isInCurrentSelectionRectangle: function(x, y) {
         return this.selectionModel.isInCurrentSelectionRectangle(x, y);

--- a/src/lib/selection.js
+++ b/src/lib/selection.js
@@ -556,9 +556,8 @@ module.exports = {
 
         if (this.singleSelect()) {
             y1 = y2;
-        } else {
-            // multiple row selection
-            y2 = y2 || y1;
+        } else if (y2 === undefined) {
+            y2 = y1;
         }
 
         sm.selectRow(Math.min(y1, y2), Math.max(y1, y2));

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -607,6 +607,7 @@ var Renderer = Base.extend('Renderer', {
     renderLastSelection: function(gc) {
         var selection, left, top, width, height,
             grid = this.grid,
+            gridProps = grid.properties,
             sm = grid.selectionModel;
 
         switch (sm.getLastSelectionType()) {
@@ -622,7 +623,7 @@ var Renderer = Base.extend('Renderer', {
                 break;
 
             case 'row':
-                if (sm.getLastSelectionType(1) !== 'cell') {
+                if (!(gridProps.collapseCellSelections && sm.getLastSelectionType(1) === 'cell')) {
                     var rowSelections = sm.rowSelectionModel.selection,
                         lastRowSelection = rowSelections[rowSelections.length - 1];
 
@@ -656,7 +657,6 @@ var Renderer = Base.extend('Renderer', {
             lastScrollableRow = this.visibleRows[this.visibleRows.length - 1], // last row in scrollable data section
             firstScrollableColumn = vci[this.dataWindow.origin.x],
             firstScrollableRow = vri[this.dataWindow.origin.y],
-            gridProps = grid.properties,
             fixedColumnCount = gridProps.fixedColumnCount,
             fixedRowCount = gridProps.fixedRowCount,
             headerRowCount = grid.getHeaderRowCount();

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -343,7 +343,7 @@ var Renderer = Base.extend('Renderer', {
      * @memberOf Renderer.prototype
      * @desc Answer specific data cell coordinates given mouse coordinates in pixels.
      * @param {Point} point
-     * @returns {Point} Cell coordinates
+     * @returns {{cellEvent:CellEvent,fake:boolean}} Cell coordinates
      */
     getGridCellFromMousePoint: function(point) {
         var x = point.x,
@@ -1032,10 +1032,7 @@ var Renderer = Base.extend('Renderer', {
         config.isColumnSelected = isColumnSelected;
         config.isInCurrentSelectionRectangle = selectionModel.isInCurrentSelectionRectangle(x, r);
         config.prefillColor = prefillColor;
-
-        if (grid.mouseDownState) {
-            config.mouseDown = grid.mouseDownState.gridCell.equals(cellEvent.gridCell);
-        }
+        config.mouseDown = grid.mouseDownState && grid.mouseDownState.gridCell.equals(cellEvent.gridCell);
 
         // compute value if a calculator
         if (isUserDataArea && !(config.value && config.value.constructor === Array)) { // fastest array determination
@@ -1061,6 +1058,9 @@ var Renderer = Base.extend('Renderer', {
         // Following supports partial render:
         cellEvent.snapshot = config.snapshot;
         cellEvent.minWidth = config.minWidth;
+
+        // Following supports clicking in a renderer-defined Rectangle of a cell (in the cell's local coordinates)
+        cellEvent.clickRect = config.clickRect;
 
         return config.minWidth;
     },
@@ -1093,7 +1093,7 @@ var Renderer = Base.extend('Renderer', {
 
         dataModel = dataModel || this.grid.behavior.dataModel;
 
-        var len = len = this.visibleColumns.length;
+        var len = this.visibleColumns.length;
         if (this.grid.properties.showRowNumbers) { len++; }
         if (this.grid.behavior.hasTreeColumn()) { len++; }
         len *= this.visibleRows.length;

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -586,8 +586,6 @@ var Renderer = Base.extend('Renderer', {
 
         gc.beginPath();
 
-        this.buttonCells = {};
-
         var rowCount = this.grid.getRowCount();
         if (rowCount !== this.lastKnowRowCount) {
             var newWidth = resetRowHeaderColumnWidth.call(this, gc, rowCount);
@@ -1057,9 +1055,6 @@ var Renderer = Base.extend('Renderer', {
 
         behavior.cellPropertiesPrePaintNotification(config);
 
-        //allow the renderer to identify itself if it's a button
-        config.buttonCells = this.buttonCells;
-
         config.formatValue = grid.getFormatter(format || config.format);
 
         // Following supports partial render>
@@ -1133,11 +1128,6 @@ var Renderer = Base.extend('Renderer', {
         this.cellEventPool.forEach(function(cellEvent) {
             cellEvent._cellOwnProperties = undefined;
         });
-    },
-
-    isViewableButton: function(c, r) {
-        var key = c + ',' + r;
-        return this.buttonCells[key] === true;
     },
 
     getBounds: function() {

--- a/test/SelectionModel-tests.js
+++ b/test/SelectionModel-tests.js
@@ -27,10 +27,6 @@ var instance = [
         name:'columnSelectionModel',
         type: 'object'
     },
-    {
-        name:'lastSelectionType',
-        type: 'string'
-    },
     {name:'allRowsSelected', type:'boolean'},
     {name:'areAllRowsSelected', type:'function'},
     {name:'clear', type:'function'},


### PR DESCRIPTION
### Synopsis
1. Support for non-US keyboard layouts (resolves Issues #621 and #623; supersedes PRs #622 and #626)
2. Scrolling speed (resolves Issue #290; supersedes PR #620)
3. Fix `fin-button-pressed` event handler in TestBench (demo)
4. Fix `Renderer.prototype.findCell`
5. Add `config.clickRect` write-only prop for cell renderer
6. Draw frame around last row or column selection
7. Add "collapse cell selections" testbench feature
8. Allow auto-row and -column selection without cell selection
9. Fix and enhance testbench's `Time` cell editor

### 1. Support for non-US keyboard layouts

Hypergrid until now has depended on the long-deprecated `KeyboardEvent#keyCode` to infer the printable character. This assumes a particular keyboard layout and mapping of `keyCode` to physical keys.

#### Issue #621: _Characters are wrongly mapped for non-US keyboards_
This PR resolves this issue (Issue #621). The logic no longer depends on `keyCode` although the legacy logic is still in place and the legacy value is still available in `event.legacyChar`:

- `grid.canvas.getKeyChar(keyboardEvent)` now returns `keyboardEvent.key` for "printable" chars, _include the space char._
- printable chars are discriminated from non-printable characters when `key.length === 1`
- for the event `e` passed to events `fin-keydown`, `fin-keyup`, `fin-editor-keydown`, `fin-editor-keypress`, and `fin-editor-keyup`:
- `e.char` is still set as before by `grid.canvas.getKeyChar(e)` but now contains the new result
- `e.legacyChar` (new prop) is the old `e.char` value, when available (depends on `keyCode` still working and charMap coverage)
- for non-printable chars (`e.legacyChar.length > 1`), `e.char === e.legacyChar` (still)

#### There are two breaking changes:
1. The space bar previously returned `e.char === 'SPACE'` and therefore was considered a non-printable char. It is now considered a printable char, and `e.char === ' '` instead.
2. On the Mac, option (aka meta) + printable char generally returns generates some exotic printable char. Like non-US keyboard characters, these were previously lost. Now however `e.char` will contain the exotic char while `e.legacyChar` will contain the old value (the regular character as if the meta key was not down).

#### Issue #623: _Space key does not open cell editor_
The first breaking change above has the side-effect of also resolving #623: _Space key does not open cell editor_

### 2. Scrolling speed (Issue #290)

Added two new properties which are multipliers for the mouse wheel:
* `wheelHFactor: 0.02` - multiplier for horizontal mouse wheel movement, applied to values of [`WheelEvent#deltaX`](https://developer.mozilla.org/docs/Web/API/WheelEvent/deltaX) (received by the horizontal scrollbar's listener).
* `wheelVFactor: 0.05` - multiplier for vertical mouse wheel movement, applied to values of [`WheelEvent#deltaY`](https://developer.mozilla.org/docs/Web/API/WheelEvent/deltaY) (received by the vertical scrollbar's listener).

#### Caveat
Wheel granularity depends on the OS, the input device, and possibly the browser. Any setting you choose will work differently in different environments. If you don't know the user's environment, it is probably best to give users control of this setting so they can fine tune it themselves.

#### Default values
The particular default values shown above are a compromise. These settings seem to work well on the MacBook Pro trackpad. They also seem to work acceptably (though differently) with a mouse wheel on both Mac OS and Windows.

Be aware however that the trackpad scrolling speed can be adjusted by the Mac user at the OS level (System Preferences -> Accessibility -> Mouse & Trackpad -> Trackpad Options… -> Scrolling speed). Mouse wheel scrolling speed is also adjustable ( _yada yada_ -> Mouse Options… -> Scrolling speed; or on Windows search for "Change mouse wheel settings" in the Start menu). 

This setting feels good on trackpad (2-finger drag). It's much slower than it was, but the way it was was way to coarse and fast, scrolling hundreds of rows in a flash.

With this setting, a mouse connected to a Mac, the wheel requires 5 click-stops to scroll 1 row; the same mouse connected to Windows scrolls 5 rows per click-stop. (However, I may have changed the default settings on my machines; not sure.)

On Windows, the original vertical multiplier setting (_i.e.,_ `1.0`) scrolled 100 grid rows on a single mouse wheel click-stop; the new default (`0.05`) scrolls 5 rows per click-stop. It stands to reason therefore that a setting of `0.01` will scroll 1:1 (1 row per 1 click-stop).

#### Hint
You can tell if the user is using a trackpad by listening for any deltaX (since a simple mouse wheel is deltaY only); and what OS by checking user agent.

### 3. Fix `fin-button-pressed` event handler in TestBench (demo)

Fixed an issue that prevented the `fin-button-pressed` event from being fired when user clicks on a cell rendered by the `Button` cell renderer.

Also retired the following core code which supported this event:
* `grid.renderer.buttonCells` object
* `config.buttonCells` object (reference to `grid.renderer.buttonCells`
* `grid.renderer.isViewableButton(c, r)` method
* `grid.isViewableButton(c, r)` method (stub that calls the `renderer` version)

The above code, intended for internal use only, tracked and identified the set of visible cells rendered by the `Button` cell renderer so that clicking them could dispatch the `fin-button-pressed` event. That solution may have been left over from an early release that lacked general column properties (much less cell properties). In any case, it has been updated to simply check the cell's cell renderer name (`event.properties.renderer === 'button'`).

### 4. Fix `Renderer.prototype.findCell`
* Fixed a bug in `Renderer.prototype.findCell` where the `cellEvent[]` pool size was being miscalculated because it was not accounting for row number column and/or tree column (when present). Previously, when these columns were present the algorithm was failing to scan enough elements and was therefore missing targets in the last 1 or 2 columns.
* Upgraded `grid.renderer.getGridCellFromMousePoint` to return the actual `cellEvent` from the pool (rather than a new one with the same coordinates) so that decorations added by the cell renderer are now available to mouse events, in particular the new `clickRect` property described below.

### 5. Add `config.clickRect` write-only prop for cell renderer
* Using local cell coordinates, cell renderers can now at their option define a `require('rectangular').Rectangle` object (aka `fin.Hypergrid.rectangular.Rectangle` in the `fin-hypergrid.js` build) in the `config.clickRect` property, which the grid renderer then copies back onto the `cellEvent` object.
* The `fin-canvas-click` event received from the canvas was previously always re-fired as the `fin-click` event. This event is now ignored however in the following cases:
   1. This event is now ignored if the mouse button was released when the mouse was no longer hovering over the cell it was over when the mouse button was depressed. Previously this event was always fired regardless because as it was is actually triggered by the browser on the entire `<canvas>` element, it fired even when the mouse was moved to another cell before releasing the mouse button.
   2. _When and only when a `clickRect` subrect was defined on the event by the cell renderer:_ This event is now ignored if the mouse button was released when the mouse was no longer hovering over the `clickRect` (as it was when it was the mouse button was depressed).
* Note that `fin-mouseup` and `fin-double-click` are unaffected by this change.

### 6. Draw frame around last row or column selection
* Draw a frame around the visible portion of the last selection including row and column selections. Previously this feature only pertained to cell region selections. It now pertains to whatever was selected last. It is smart about deselecting.
* Copy operation now copies the last selection (thing with the frame now drawn around it). Previously cell region selections always had priority, then row selections, then column selections.
* _Exception:_ The collapse cell region feature which collapses a cell region selection to a new row selection, continues to draw the frame around just the cells (the previous behavior). Note that this feature is only active when `grid.properties.singleRowSelectionMode && !grid.properties.multipleSelections` (which are the default settings).

### 7. Add "collapse cell selections" testbench feature
This feature has been imported from the "testbench" demo as a new option `collapseCellSelections` but it now defaults to `false`. You can turn it back on in the Dashboard -> Selections panel.

This feature basically causes row selections to move the last cell selection to the new row selection.

This feature only works in single row selection mode when selecting one row at a time (`singleRowSelectionMode && !multipleSelections`).

### 8. Allow auto-row and -column selection without cell selection
Previously, `autoRowSelection` and/or `autoColumnSelection` caused cell selection to select the row and/or column. This had the sometimes undesirable effect of selecting a cell along with the row and/or column. Prior to this release, this cell was always framed. This was because cells always had priority for framing although this is no longer the case (see item 6 above). Although this is no longer the case, the cell is still framed if the `collapseCellSelections` feature is active (see item 7 above); or if the row is subsequently deselected with a CTRL-click in the row handle cell.

With this change, rows and/or columns are now auto-selectable per `autoRowSelection` and/or `autoColumnSelection` _even when_ cell selection is **off** (`cellSelection = false`). This configuration is preferable when you don't need cell selections and it also permits row deselection via CTRL-click _anywhere in the row_ — rather requiring the click to be in the row handle cell.

### 9. Fix and enhance testbench's `Time` cell editor
* Restore missing `NOON` constant definition required by `hhmm` localizer and `Time` cell editor.
* Enhance `hhmm` cell editor to allow typing "AM" or "PM" to toggle AM/PM. After toggling, the input is discarded (by calling `preventDefault`). This is in addition to the existing interface which requires clicking "AM" or "PM" to toggle it.
* Enhance `hhmm` cell editor by "rejecting" (with the error feedback effect) all other chars besides digits and colon.

### Defunct issues and PRs
All the above mentioned Issues (#621, #623, #290) and competing pull requests (#622, #626, and #620) have been closed.