### PR TITLE
Hypergrid v2.1.14

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "jsdoc-template-hypergrid"]
 	path = jsdoc-template-hypergrid
-	url = https://github.com/openfin/jsdoc-template-hypergrid
+	url = https://github.com/fin-hypergrid/jsdoc-template-hypergrid

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ It also highlights a DOM-based custom external editor triggered via hypergrid ev
 * [Roadmap](#roadmap)
 * [Contributing](#contributors)
 
-### Current Release (2.1.13 - 12 June 2018)
+### Current Release (2.1.14 - 12 June 2018)
 
-**Hypergrid 2.1.13** includes bug fixes, new features, and a couple of additional demos.
+**Hypergrid 2.1.14** includes bug fixes.
 
 _For a complete list of changes, see the [release notes](https://github.com/fin-hypergrid/core/releases)._
 
@@ -52,13 +52,13 @@ Find more information on our [testing page](TESTING.md)
 
 Primarily our tutorials will be on the [wiki](https://github.com/fin-hypergrid/core/wiki).
 
-We also maintain versioned [online API documentation](https://fin-hypergrid.github.io/core/2.1.13/doc/Hypergrid.html) for all public objects and modules. This documentation is necessarily an on-going work-in-progress.
+We also maintain versioned [online API documentation](https://fin-hypergrid.github.io/core/2.1.14/doc/Hypergrid.html) for all public objects and modules. This documentation is necessarily an on-going work-in-progress.
 
 (Cell editor information can be found [here](https://github.com/fin-hypergrid/core/wiki/Cell-Editors).)
 
 (Cell Rendering information can be found [here](https://github.com/fin-hypergrid/core/wiki/Cell-Renderers).)
 
-Hypergrid global configurations can be found [here](https://fin-hypergrid.github.io/core/2.1.13/doc/module-defaults.html).
+Hypergrid global configurations can be found [here](https://fin-hypergrid.github.io/core/2.1.14/doc/module-defaults.html).
 
 ### Roadmap
 

--- a/demo/filter-row.html
+++ b/demo/filter-row.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" >
+</head>
+<body>
+
+    <script src="build/fin-hypergrid.js"></script>
+
+    <script>
+window.onload = function() {
+    var data = [
+        { symbol: 'APPL', name: 'Apple Inc.', prevclose: 93.13 },
+        { symbol: 'MSFT', name: 'Microsoft Corporation', prevclose: 51.91 },
+        { symbol: 'TSLA', name: 'Tesla Motors Inc.', prevclose: 196.40 },
+        { symbol: 'IBM', name: 'International Business Machines Corp', prevclose: 155.35 }
+    ];
+    var grid = window.grid = new fin.Hypergrid();
+    grid.setData(data);
+
+    fin.Hypergrid.dataModels.add('FilterSubgrid', fin.Hypergrid.dataModels.DataModel.extend({
+        type: 'filter',
+
+        format: 'filter', // this signals to renderer to override column localizer for these cells
+
+        initialize: function (grid) {
+            this.grid = grid;
+        },
+
+        getRow: function (y) {
+            return this.grid.behavior.getColumns().map(function (column) {
+                return column.filter || '';
+            });
+        },
+
+        getRowCount: function () {
+            return this.grid.properties.showFilterRow ? 1 : 0;
+        },
+
+        getValue: function (x, y) {
+            return this.grid.behavior.getColumn(x).properties.filter || '';
+        },
+
+        setValue: function (x, y, value) {
+            var column = this.grid.behavior.getColumn(x).properties.filter = value;
+        }
+    }));
+
+    // bonus feature: immediate mode filters on every keypress
+    grid.cellEditors.add(grid.cellEditors.get('Textfield').extend('FilterEditor', {
+        keyup: function (event) {
+            if (
+                !this.super.keyup.call(this, event) &&
+                this.grid.properties.filteringMode === 'immediate'
+            ) {
+                try {
+                    this.saveEditorValue(this.getEditorValue());
+                } catch (err) {
+                    // ignore syntax errors in immediate mode
+                }
+            }
+        },
+
+        saveEditorValue: function(value) {
+            var save = !arguments.length || value !== this.initialValue;
+
+            if (save) {
+                this.grid.behavior.setValue(this.event, value);
+                this.grid.fireSyntheticFilterAppliedEvent();
+            }
+
+            return save;
+        }
+    }));
+
+
+    grid.properties.subgrids = [
+        'HeaderSubgrid',
+        'FilterSubgrid',
+        'data'
+    ];
+    grid.properties.showFilterRow = true;
+
+    var version = grid.version.split('.');
+    if (
+        Number(version[0]) >= 2 &&
+        Number(version[1]) >= 1 &&
+        Number(version[2]) >= 14
+    ) {
+        // new way
+        grid.properties.filterEditor = 'FilterEditor';
+    } else {
+        // old way makes works when whole grid editable...
+        grid.properties.editor = 'Textfield'; // must be something in order for getCellEditorAt to be called
+        grid.behavior.dataModel.getCellEditorAt = function(columnIndex, rowIndex, editorName, cellEvent) {
+            if (cellEvent.isFilterCell) {
+                editorName = 'FilterEditor';
+            }
+            return cellEvent.grid.cellEditors.create(editorName, cellEvent);
+        }
+    }
+
+    grid.addEventListener('fin-filter-applied', function(e) {
+        console.log('Filters:', this.grid.behavior.getColumns().reduce(function (obj, column) {
+            if (column.properties.filter) {
+                obj[column.name] = column.properties.filter;
+            }
+            return obj;
+        }, {}));
+    })
+};
+    </script>
+
+</body>
+</html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -22,7 +22,7 @@
     b = g.behavior,
     m = b.dataModel;">top-level global vars</label>
 
-    <h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.13 dev testbench</h1>
+    <h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.14 dev testbench</h1>
 
     <div id="tabs">
         <div id="tab-dashboard">Dashboard</div>

--- a/demo/multiple-grids.html
+++ b/demo/multiple-grids.html
@@ -5,7 +5,7 @@
     <style> body > div.hypergrid-container { width: 415px; margin-right: 10px; display: inline-block }</style>
 </head>
 <body>
-<h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.13 multiple grids demo</h1>
+<h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.14 multiple grids demo</h1>
 
 <script src="build/fin-hypergrid.js"></script>
 

--- a/demo/over-render.html
+++ b/demo/over-render.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" >
+</head>
+<body>
+
+
+    <script src="build/fin-hypergrid.js"></script>
+
+    <script>
+        var data = [
+            { symbol: 'APPL', name: 'Apple Inc.', prevclose: 93.13 },
+            { symbol: 'MSFT', name: 'Microsoft Corporation', prevclose: 51.91 },
+            { symbol: 'TSLA', name: 'Tesla Motors Inc.', prevclose: 196.40 },
+            { symbol: 'IBM', name: 'International Business Machines Corp', prevclose: 155.35 }
+        ];
+        var grid = new fin.Hypergrid();
+        grid.setData(data);
+
+        grid.properties.renderer = ['SimpleCell', 'Tag'];
+        grid.behavior.columns.prevclose.properties.tagbands = [
+            { floor: 128, fillStyle: 'green' },
+            { floor: 64, fillStyle: '#e0e020' },
+            { floor: 0, fillStyle: 'red' }
+        ];
+    </script>
+</body>
+</html>

--- a/demo/row-props.html
+++ b/demo/row-props.html
@@ -38,7 +38,7 @@
     </style>
 </head>
 <body>
-<h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.13 performance workbench</h1>
+<h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.14 performance workbench</h1>
 
 <div id="controls" class="nowrap">
     <label id="controller" title="Uncheck to hide other controls.">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fin-hypergrid",
-  "version": "2.1.13",
+  "version": "2.1.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fin-hypergrid",
-  "version": "2.1.13",
+  "version": "2.1.14",
   "description": "Canvas-based high-performance grid",
   "repository": {
     "type": "git",

--- a/src/Base.js
+++ b/src/Base.js
@@ -19,6 +19,16 @@ Object.defineProperty(Base.prototype, 'version', {
     value: require('../package.json').version
 });
 
+Base.prototype.atLeastVersion = function(neededVersion) {
+    var neededParts = neededVersion.split('.'),
+        thisParts = this.version.split('.'),
+        delta;
+    neededParts.find(function(neededPart, i) {
+        return (delta = neededPart - thisParts[i]);
+    });
+    return delta >= 0;
+};
+
 Base.prototype.deprecated = require('./lib/deprecated');
 Base.prototype.HypergridError = require('./lib/error');
 

--- a/src/Hypergrid.js
+++ b/src/Hypergrid.js
@@ -27,7 +27,10 @@ var EDGE_STYLES = ['top', 'bottom', 'left', 'right'],
 
 /**
  * @mixes scrolling.mixin
- * @mixes themes.instanceMixin
+ * @mixes events.mixin
+ * @mixes selection.mixin
+ * @mixes themes.mixin
+ * @mixes themes.sharedMixin
  * @constructor
  * @param {string|Element} [container] - CSS selector or Element
  * @param {object} [options]
@@ -212,7 +215,6 @@ var Hypergrid = Base.extend('Hypergrid', {
     },
 
     /**
-     *
      * A null object behavior serves as a place holder.
      * @type {object}
      * @memberOf Hypergrid#
@@ -220,7 +222,8 @@ var Hypergrid = Base.extend('Hypergrid', {
     behavior: null,
 
     /**
-     * Cached resulan}
+     * Cached result of webkit test.
+     * @type {boolean}
      * @memberOf Hypergrid#
      */
     isWebkit: true,
@@ -237,33 +240,29 @@ var Hypergrid = Base.extend('Hypergrid', {
      * @type {Point}
      * @memberOf Hypergrid#
      */
-
     dragExtent: null,
 
     /**
-     * @property {fin-hypergrid-selection-model} selectionModel - A [fin-hypergrid-selection-model](module-._selection-model.html) instance.
+     * The instance of the grid's selection model.
+     * May or may not contain any cell, row, and/or column selections.
+     * @type {SelectionModel}
      * @memberOf Hypergrid#
      */
     selectionModel: null,
 
     /**
-     * @property {fin-hypergrid-cell-editor} cellEditor - The current instance of [fin-hypergrid-cell-editor](module-cell-editors_base.html).
+     * The instance of the currently active cell editor.
+     * Will be `null` when not editing.
+     * @type {CellEditor}
      * @memberOf Hypergrid#
      */
     cellEditor: null,
 
     /**
-     * @property {fin-vampire-bar} sbHScroller - An instance of {@link https://github.com/openfin/finbars|FinBar}.
-     * @memberOf Hypergrid#
-     */
-    sbHScroller: null,
-
-    /**
-     * is the short term memory of what column I might be dragging around
+     * Non-`null` members represent additional things to render, after rendering the grid, such as the column being dragged.
      * @type {object}
      * @memberOf Hypergrid#
      */
-
     renderOverridesCache: {},
 
     /**
@@ -401,8 +400,6 @@ var Hypergrid = Base.extend('Hypergrid', {
      * The "`installPlugins` calling context" means either the grid instance or its prototype, depending on how this method is called.
      *
      * Plugins may have both `preinstall` _and_ `install` methods, in which case both will be called. However, note that in any case, `install` methods on object API plugins are ignored.
-     *
-     * @this {Hypergrid}
      * @param {pluginSpec|pluginSpec[]} [plugins] - The plugins to install. If omitted, the call is a no-op.
      * @memberOf Hypergrid#
      */

--- a/src/behaviors/Behavior.js
+++ b/src/behaviors/Behavior.js
@@ -7,7 +7,6 @@ var Column = require('./Column');
 var cellEventFactory = require('../lib/cellEventFactory');
 var featureRegistry = require('../features');
 var Synonomous = require('synonomous');
-var propClassEnum = require('../defaults.js').propClassEnum;
 var assignOrDelete = require('../lib/misc').assignOrDelete;
 
 
@@ -166,15 +165,15 @@ var Behavior = Base.extend('Behavior', {
             tc = this.treeColumnIndex,
             rc = this.rowColumnIndex;
 
-        schema[tc] = schema[tc] || {
-            name: 'Tree',
-            header: 'Tree'
-        };
+        schema[tc] = schema[tc] || {};
+        schema[tc].index = tc;
+        if (schema[tc].name === undefined) { schema[tc].name = 'Tree'; }
+        if (schema[tc].header === undefined) { schema[tc].header = 'Tree'; }
 
-        schema[rc] = schema[rc] || {
-            name: '',
-            header: ''
-        };
+        schema[rc] = schema[rc] || {};
+        schema[rc].index = rc;
+        if (schema[rc].name === undefined) { schema[rc].name = 'RowHeader'; }
+        if (schema[rc].header === undefined) { schema[rc].header = ''; }
 
         /**
          * @type {Column[]}
@@ -188,16 +187,10 @@ var Behavior = Base.extend('Behavior', {
          */
         this.allColumns = [];
 
-        this.allColumns[tc] = this.columns[tc] = this.newColumn({
-            index: tc,
-            header: schema[tc].header
-        });
-        this.allColumns[rc] = this.columns[rc] = this.newColumn({
-            index: rc,
-            header: schema[rc].header
-        });
+        this.allColumns[tc] = this.columns[tc] = this.newColumn(schema[tc]);
+        this.allColumns[rc] = this.columns[rc] = this.newColumn(schema[rc]);
 
-        this.columns[tc].properties.propClassLayers = this.columns[rc].properties.propClassLayers = [propClassEnum.COLUMNS];
+        this.columns[tc].properties.propClassLayers = this.columns[rc].properties.propClassLayers = this.grid.properties.propClassLayersMap.NO_ROWS;
 
         // Signal the renderer to size the now-reset handle column before next render
         this.grid.renderer.resetRowHeaderColumnWidth();

--- a/src/behaviors/cellProperties.js
+++ b/src/behaviors/cellProperties.js
@@ -154,13 +154,17 @@ function newCellPropertiesObject(rowIndex, dataModel) {
     var metadata = (dataModel || this.dataModel).getRowMetadata(rowIndex, {}),
         props = this.properties;
 
-    switch (this._index) {
+    switch (this.index) {
         case this.behavior.treeColumnIndex:
             props = this.properties.treeHeader;
             break;
         case this.behavior.rowColumnIndex:
             props = this.properties.rowHeader;
             break;
+        default:
+            if (dataModel && dataModel.type === 'filter') {
+                props = this.properties.filterProperties;
+            }
     }
 
     return (metadata[this.name] = Object.create(props));

--- a/src/behaviors/columnProperties.js
+++ b/src/behaviors/columnProperties.js
@@ -335,6 +335,16 @@ createColumnProperties.filterDescriptors = {
             this.filterRenderer = value;
         }
     },
+    editor: {
+        configurable: true,
+        enumerable: true,
+        get: function() {
+            return this.filterEditor;
+        },
+        set: function(value) {
+            this.filterEditor = value;
+        }
+    },
     rightIcon: {
         configurable: true,
         enumerable: true,

--- a/src/cellEditors/CellEditor.js
+++ b/src/cellEditors/CellEditor.js
@@ -382,7 +382,7 @@ var CellEditor = Base.extend('CellEditor', {
      * @memberOf CellEditor.prototype
      */
     getEditorValue: function(str) {
-        return this.localizer.parse(str);
+        return this.localizer.parse(str || this.input.value);
     },
 
     /**
@@ -393,7 +393,7 @@ var CellEditor = Base.extend('CellEditor', {
      * @memberOf CellEditor.prototype
      */
     validateEditorValue: function(str) {
-        return this.localizer.invalid && this.localizer.invalid(str);
+        return this.localizer.invalid && this.localizer.invalid(str || this.input.value);
     },
 
     /**

--- a/src/cellRenderers/Button.js
+++ b/src/cellRenderers/Button.js
@@ -10,7 +10,6 @@ var Button = CellRenderer.extend('Button', {
 
     /**
      * @summary The default cell rendering function for a button cell.
-     * @implements paintFunction
      * @memberOf Button.prototype
      */
     paint: function(gc, config) {

--- a/src/cellRenderers/LastSelection.js
+++ b/src/cellRenderers/LastSelection.js
@@ -10,7 +10,6 @@ var LastSelection = CellRenderer.extend('LastSelection', {
 
     /**
      * @desc A rendering of the last Selection Model
-     * @implements paintFunction
      * @memberOf LastSelection.prototype
      */
     paint: function(gc, config) {

--- a/src/cellRenderers/SimpleCell.js
+++ b/src/cellRenderers/SimpleCell.js
@@ -14,7 +14,6 @@ var SimpleCell = CellRenderer.extend('SimpleCell', {
     /**
      * @summary The default cell rendering function for rendering a vanilla cell.
      * @desc Great care has been taken in crafting this function as it needs to perform extremely fast. Reads on the gc object are expensive but not quite as expensive as writes to it. We do our best to avoid writes, then avoid reads. Clipping bounds are not set here as this is also an expensive operation. Instead, we truncate overflowing text and content by filling a rectangle with background color column by column instead of cell by cell.  This column by column fill happens higher up on the stack in a calling function from fin-hypergrid-renderer.  Take note we do not do cell by cell border rendering as that is expensive.  Instead we render many fewer gridlines after all cells are rendered.
-     * @implements paintFunction
      * @memberOf SimpleCell.prototype
      */
     paint: function(gc, config) {

--- a/src/cellRenderers/SliderCell.js
+++ b/src/cellRenderers/SliderCell.js
@@ -10,7 +10,6 @@ var Slider = CellRenderer.extend('Slider', {
 
     /**
      * @desc Emerson's paint function for a slider button. currently the user cannot interact with it
-     * @implements paintFunction
      * @memberOf Slider.prototype
      */
     paint: function(gc, config) {

--- a/src/cellRenderers/SparkBar.js
+++ b/src/cellRenderers/SparkBar.js
@@ -10,7 +10,6 @@ var SparkBar = CellRenderer.extend('SparkBar', {
 
     /**
      * @desc A simple implementation of a sparkline, because it's a barchart we've changed the name ;).
-     * @implements paintFunction
      * @memberOf SparkBar.prototype
      */
     paint: function(gc, config) {

--- a/src/cellRenderers/SparkLine.js
+++ b/src/cellRenderers/SparkLine.js
@@ -10,7 +10,6 @@ var SparkLine = CellRenderer.extend('SparkLine', {
 
     /**
      * @desc A simple implementation of a sparkline.  see [Edward Tufte sparkline](http://www.edwardtufte.com/bboard/q-and-a-fetch-msg?msg_id=0001OR)
-     * @implements paintFunction
      * @memberOf SparkLine.prototype
      */
     paint: function(gc, config) {

--- a/src/cellRenderers/Tag.js
+++ b/src/cellRenderers/Tag.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var CellRenderer = require('./CellRenderer');
+
+/**
+ * @constructor
+ * @extends CellRenderer
+ */
+var Tag = CellRenderer.extend('Tag', {
+
+    /**
+     * @memberOf Tag.prototype
+     */
+    paint: function(gc, config) {
+        if (config.tagbands) {
+            var tagband = config.tagbands.find(function(tagband) {
+                return config.value >= tagband.floor;
+            });
+            var fillStyle = tagband && tagband.fillStyle;
+
+            if (fillStyle) {
+                var b = config.bounds,
+                    x = b.x + b.width - 1,
+                    y = b.y;
+
+                gc.beginPath();
+                gc.moveTo(x, y);
+                gc.lineTo(x, y + 8);
+                gc.lineTo(x - 8, y);
+                // gc.lineTo(x, y);
+                gc.closePath();
+                gc.cache.fillStyle = fillStyle;
+                gc.fill();
+            }
+        }
+    }
+});
+
+module.exports = Tag;

--- a/src/cellRenderers/TreeCell.js
+++ b/src/cellRenderers/TreeCell.js
@@ -10,7 +10,6 @@ var TreeCell = CellRenderer.extend('TreeCell', {
 
     /**
      * @desc A simple implementation of a tree cell renderer for use mainly with the tree column.
-     * @implements paintFunction
      * @memberOf TreeCell.prototype
      */
     paint: function(gc, config) {

--- a/src/cellRenderers/index.js
+++ b/src/cellRenderers/index.js
@@ -22,7 +22,9 @@ var CellRenderers = Registry.extend('CellRenderers', {
         this.add(require('./LastSelection'));
         this.add(require('./SparkLine'));
         this.add(require('./ErrorCell'));
+        this.add(require('./Tag'));
         this.add(require('./TreeCell'));
+        this.add('emptycell', this.BaseClass); // remove this when deprecation below retired
     },
 
     // for better performance, instantiate at add time rather than render time.
@@ -36,15 +38,21 @@ var CellRenderers = Registry.extend('CellRenderers', {
     },
 
     get: function(name) {
-        if (name && name.toLowerCase() === 'emptycell') {
+        if (name.map) {
+            return name.map(function(name) {
+                return Registry.prototype.get.call(this, name);
+            }, this);
+        }
+
+        var cellRenderer = Registry.prototype.get.call(this, name);
+        if (cellRenderer === this.items.emptycell) {
             if (!warnedBaseClass) {
                 console.warn('grid.cellRenderers.get("' + name + '").constructor has been deprecated as of v2.1.0 in favor of grid.cellRenderers.BaseClass property. (Will be removed in a future release.)');
                 warnedBaseClass = true;
             }
             this.BaseClass.constructor = this.BaseClass;
-            return this.BaseClass;
         }
-        return Registry.prototype.get.call(this, name);
+        return cellRenderer;
     }
 
 });

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -365,6 +365,13 @@ var defaults = {
 
     /**
      * @default
+     * @type {string}
+     * @memberOf module:defaults
+     */
+    filterEditor: undefined,
+
+    /**
+     * @default
      * @type {boolean}
      * @memberOf module:defaults
      */

--- a/src/features/RowSelection.js
+++ b/src/features/RowSelection.js
@@ -66,11 +66,14 @@ var RowSelection = Feature.extend('RowSelection', {
      * @param {Object} event - the event details
      */
     handleMouseDown: function(grid, event) {
-        var rowSelectable = grid.properties.rowSelection &&
-            !event.primitiveEvent.detail.isRightClick && (
-                grid.properties.autoSelectRows ||
-                grid.properties.showRowNumbers && event.isHandleColumn
-            );
+        var leftClick = !event.primitiveEvent.detail.isRightClick,
+            rowNumberClick = leftClick && grid.properties.showRowNumbers && event.isHandleColumn;
+
+        if (rowNumberClick && !grid.fireSyntheticRowHeaderClickedEvent(event)) {
+            return;
+        }
+
+        var rowSelectable = grid.properties.rowSelection && (leftClick && grid.properties.autoSelectRows || rowNumberClick);
 
         if (rowSelectable && event.isHeaderHandle) {
             //global row selection

--- a/src/jsdoc/interfaces/localization.js
+++ b/src/jsdoc/interfaces/localization.js
@@ -2,7 +2,7 @@
 
 /** @interface localizerInterface
  * @desc Implemented by instances of {@link NumberFormatter} and {@link DateFormatter}.
- * Note however that a custom implementation need to be created by such a factory object; it only needs to implement the required properties.
+ * Note however that it not a requirement that a custom localizer implementation be created from such a factory object; it only needs to implement the required methods described below (_i.e.,_ `format` and `parse`).
  */
 
 /**
@@ -37,14 +37,12 @@
  * @summary Tests string representation for invalidity.
  * @desc Implementation of this method is optional.
  *
- * The method may be strict or loose but caller has no way of knowing and must assume loose. Loose means it may return a false negative. This means that while a truthy return means invalid, falsy merely means "not invalid." The parser is the final arbiter and should throw an error on parser jam.
+ * Return an error message here only if you can describe what precisely caused the syntax error. If all you know is that there was a syntax error, return `true`. In such a case it would be helpful to also define {@link localizerInterface#expectation expectation}, which is appended to all error messages, and should contain a general description of the expected syntax.
  *
- * Return an error message here only if you can describe what precisely caused the syntax error. If all you know is that there was a syntax error, it would probably be more helpful to the user to define {@link localizerInterface#expectation expectation}, which is appended to all error messages, and should contain a general description of the expected syntax.
- *
- * Overridden by `options.invalid` passed to constructor.
+ * Overridden by `options.invalid` passed to a factory constructor ({@link NumberFormatter} or {@link DateFormatter}).
  * @method
  * @returns {boolean|string} Truthy value means invalid. If a string, this will be an error message. If not a string, it merely indicates a generic invalid result.
- * @throws {boolean|string|Error} May throw an error on syntax failure as an alternative to returning truthy. Define the error's `message` field as an alternative to returning string.
+ * @throws {Error} May throw an error on syntax failure as an alternative to returning truthy. Define the error's `message` field as an alternative to returning string.
  */
 
 /**
@@ -56,13 +54,14 @@
  *
  * If undefined and in the absence of an error message, the user will know only that the value is invalid but nothing else.
  *
- * Overridden by `options.expectation` passed to constructor.
+ * Overridden by `options.expectation` passed to factory constructor ({@link NumberFormatter} or {@link DateFormatter}).
  *
  * @type {string}
  */
 
 /**
  * @name localizerInterface#locale
- * @summary Locale provided to constructor. Required.
+ * @summary Locale for formatting purposes.
+ * @desc A locale value is required as the 2nd parameter (`locale`) to a factory constructor ({@link NumberFormatter} or {@link DateFormatter}).
  * @type {string}
  */

--- a/src/lib/Registry.js
+++ b/src/lib/Registry.js
@@ -57,7 +57,7 @@ var Registry = Base.extend('Registry', {
      * @memberOf Registry#
      */
     addSynonym: function(synonymName, existingName) {
-        return (this.items[synonymName] = this.get(existingName));
+        return (this.items[synonymName] = this.items[existingName]);
     },
 
     /**

--- a/src/lib/Registry.js
+++ b/src/lib/Registry.js
@@ -38,7 +38,15 @@ var Registry = Base.extend('Registry', {
             throw new this.HypergridError('Cannot register ' + this.friendlyName() + ' without a name.');
         }
 
-        return (this.items[name] = item);
+        this.items[name] = item;
+
+        // update existing keys that differ only in case
+        name = name.toLowerCase();
+        Object.keys(this.items)
+            .filter(function(key) { return key.toLowerCase() === name; })
+            .forEach(function(key) { this.items[key] = item; }, this);
+
+        return item;
     },
 
     /**

--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -6,6 +6,12 @@ var _ = require('object-iterators');
 
 var Behavior = require('../behaviors/Behavior');
 
+/**
+ * Additions to `Hypergrid.prototype` for handling and firing events.
+ *
+ * All members are documented on the {@link Hypergrid} page.
+ * @mixin events.mixin
+ */
 module.exports = {
 
     /**

--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -157,6 +157,10 @@ module.exports = {
         });
     },
 
+    fireSyntheticRowHeaderClickedEvent: function(event) {
+        return dispatchEvent.call(this, 'fin-row-header-clicked', true, {}, event);
+    },
+
     /**
      * @memberOf Hypergrid#
      * @desc Synthesize and fire a `fin-row-selection-changed` event.

--- a/src/lib/scrolling.js
+++ b/src/lib/scrolling.js
@@ -4,7 +4,9 @@ var Scrollbar = require('./modules').Scrollbar;
 
 /**
  * Additions to `Hypergrid.prototype` for scrollbar support.
- * @mixin
+ *
+ * All members are documented on the {@link Hypergrid} page.
+ * @mixin scrolling.mixin
  */
 exports.mixin = {
 
@@ -23,10 +25,18 @@ exports.mixin = {
     hScrollValue: 0,
 
     /**
-     * @property {fin-vampire-bar} sbVScroller - An instance of {@link https://github.com/openfin/finbars|FinBar}.
+     * The verticl scroll bar model/controller.
+     * @type {FinBar}
      * @memberOf Hypergrid#
      */
     sbVScroller: null,
+
+    /**
+     * The horizontal scroll bar model/controller.
+     * @type {FinBar}
+     * @memberOf Hypergrid#
+     */
+    sbHScroller: null,
 
     /**
      * The previous value of sbVScrollVal.

--- a/src/lib/selection.js
+++ b/src/lib/selection.js
@@ -4,6 +4,12 @@
 
 var Rectangle = require('rectangular').Rectangle;
 
+/**
+ * Additions to `Hypergrid.prototype` for modeling cell, row, and column selections.
+ *
+ * All members are documented on the {@link Hypergrid} page.
+ * @mixin selection.mixin
+ */
 module.exports = {
     selectionInitialize: function() {
         var grid = this;

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -1102,7 +1102,13 @@ var Renderer = Base.extend('Renderer', {
         config.minWidth = cellEvent.minWidth; // in case `paint` aborts before setting `minWidth`
 
         // Render the cell
-        cellRenderer.paint(gc, config);
+        if (cellRenderer.forEach) {
+            cellRenderer.forEach(function(subrenderer) {
+                subrenderer.paint(gc, config);
+            });
+        } else {
+            cellRenderer.paint(gc, config);
+        }
 
         // Following supports partial render:
         cellEvent.snapshot = config.snapshot;

--- a/src/themes.js
+++ b/src/themes.js
@@ -163,7 +163,9 @@ function applyTheme(theme) {
 
 /**
  * Additions to `Hypergrid.prototype` for setting an instance theme.
- * @mixin
+ *
+ * All members are documented on the {@link Hypergrid} page.
+ * @mixin themes.mixin
  */
 var mixin = {
     initThemeLayer: function() {
@@ -218,8 +220,10 @@ Object.defineProperty(mixin, 'theme', {
 
 
 /**
- * Shared properties of `Hypergrid` for registering themes and setting a global theme.
- * @mixin
+ * Shared properties of `Hypergrid` "class" (_i.e.,_ "static" properties of constructor function) for registering themes and setting a global theme.
+ *
+ * All members are documented on the {@link Hypergrid} page (annotated as "(static)").
+ * @mixin themes.sharedMixin
  */
 var sharedMixin = {
     /**
@@ -230,7 +234,6 @@ var sharedMixin = {
      * ```javascript
      * var myTheme = require('fin-hypergrid-themes').buildTheme();
      * ```
-     * @this {Hypergrid.constructor}
      * @memberOf Hypergrid.
      */
     registerTheme: function(name, theme) {
@@ -273,7 +276,7 @@ var sharedMixin = {
      * @summary Apply global theme.
      * @desc Apply props from the given theme object to the global theme object,
      * the `defaults` layer at the bottom of the properties hierarchy.
-     * @this {Hypergrid.constructor}
+     * @this {Hypergrid.}
      * @param {object|string} [theme=registry.default] - One of:
      * * **string:** A registered theme name.
      * * **object:** A theme object. Empty object removes global them, restoring defaults.


### PR DESCRIPTION
## Hypergrid v2.1.14

This release adds some new features and fixes some bugs:

#### New features
1. Add support for Tree column & Row number column cell properties
2. New demo: `filter-row.html`
3. Add `editor` property for filter row cells
4. Add `Base.prototype.atLeastVersion`
5. Add support for cell renderer overlays
6. New demo: `over-render.html`
7. Add `fin-row-header-click` event (cancelable)
#### Bug fixes
1. Fixed issues with registry synonyms
2. Faster renderer lookup

## New features

### 1. Add support for Tree column & Row number column cell properties
* Properties set on Individual cells in these columns now function correctly.
* Among other things, the top-left cell can now be bound to a custom cell renderer:
   ```js
   var b = myGrid.behavior; 
   b.setCellProperty(b.rowColumnIndex, 0, 'renderer', ‘custom’, b.subgrids.lookup.header);
   ```
* Row number column now has a name: `RowHeader` (previously was empty string).

### 2. New demo: [`filter-row.html`](https://fin-hypergrid.github.io/core/2.1.14/filter-row.html)
Demonstrates how to:
   * Create and display a filter cell row
   * Bind a cell editor to it.

The included cell editor demonstrates how to:
   * Trigger the `fin-filter-applied` event when a column filter changes.
   * Implement "immediate keypress" mode (issues a filter event on every keypress rather than waiting for the editor to be closed).

### 3. Add `editor` property for filter row cells
This new property makes it much simpler to bind a cell editor to cells in the filter. Serializes as `filterEditor`.  See the `filter-row.html` demo code for example of how to bind with and without this new property.

### 4. Add `Base.prototype.atLeastVersion`
```js
if (grid.atLeastVersion('2.1.14')) {
    . . . // use a new feature
}
```

### 5. Add support for cell renderer overlays
This new feature coded to have minimal performance impact (as usual).
- A cell's `renderer` prop may now accepts an array-of-string overload of cell renderer names:
   ```js
   grid.properties.renderer = ['SimpleCell', 'Tag'];
   ```
- Each listed cell renderer will be called in turn.
- In the example above, we set the entire grid to call for every cell the `SimpleCell` cell renderer followed by the `Tag` cell renderer:
   1. `SimpleCell` — The first cell renderer listed should render the cell contents, including possibly the cell background color (as needed per grid renderer strategy).
   2. `Tag` — The remaining cell renderer(s) in the list are assumed to be "overlay renderer(s)" that add superimposed graphic elements. They are dependent on being preceded by a regular cell renderer for the basic cell contents.
- The [`Tag`](https://github.com/fin-hypergrid/core/blob/master/src/cellRenderers/Tag.js) cell renderer is provided as an example of a cell renderer intended to be used as an overlay. It renders a "tag" (small triangle) in the upper-right corner of the cell whose color is determined by the cell value.
- `Tag` only renders a tag over cells with a defined `tagbands` property. For example, cells with the following `tagbands` definition will render a green tag for values ≥ 128; else yellow for values ≥ 64; else red for the remaining positive values.:
   ```js
   myColumnOrCell.properties.tagbands = [
       { floor: 128, fillStyle: 'green' },
       { floor: 64, fillStyle: 'yellow' },
       { floor: 0, fillStyle: 'red' }
   ];
   ```
- Note that although we set the entire grid to call render `Tag` overlays, only the cells with a `tagband` property will actually render tags. (It would of course be more efficient to only set those cells' `renderer` properties to an array that includes `Tag` and leave the rest of the cells set to the scalar `SimpleCell`.)

### 6. New demo: [`over-render.html`](https://fin-hypergrid.github.io/core/2.1.14/over-render.html)
Demonstrates how cell renderer overlays work using the new `Tag` cell renderer.

### 7. Add `fin-row-header-click` event (cancelable)
Easy way to intercept a click in the row number cell to do something with the input in addition to selecting the row, or call `event.preventDefault()` in the handler to do something else _rather than_ selecting a row.

## Bug fixes

### 1. Fixed issues with registry synonyms
   * `Registry.prototype.add` now updates synonyms that differ only in case.
   * Fixed an issue with `Registry.prototype.addSynonym` issue.

### 2. Faster renderer lookup
The `cellRenderers.get('emptycell')` deprecation check is now faster by avoiding `toLowerCase(name)` on every renderer lookup.

## API docs
Simplified cell renderer jsdoc pages.
