### PR TITLE
Hypergrid v2.1.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It also highlights a DOM-based custom external editor triggered via hypergrid ev
 <img src="images/README/gridshot04.gif">
 
 ## Table of Contents
-* [Current Release](#current-release-2111---12-june-2018)
+* [Current Release](#current-release-2115---29-june-2018)
 * [Demos](#demos)
 * [Features](#features)
 * [Testing](#testing)
@@ -16,9 +16,9 @@ It also highlights a DOM-based custom external editor triggered via hypergrid ev
 * [Roadmap](#roadmap)
 * [Contributing](#contributors)
 
-### Current Release (2.1.14 - 12 June 2018)
+### Current Release (2.1.15 - 29 June 2018)
 
-**Hypergrid 2.1.14** includes bug fixes.
+**Hypergrid 2.1.15** includes bug fixes and new features.
 
 _For a complete list of changes, see the [release notes](https://github.com/fin-hypergrid/core/releases)._
 
@@ -52,13 +52,13 @@ Find more information on our [testing page](TESTING.md)
 
 Primarily our tutorials will be on the [wiki](https://github.com/fin-hypergrid/core/wiki).
 
-We also maintain versioned [online API documentation](https://fin-hypergrid.github.io/core/2.1.14/doc/Hypergrid.html) for all public objects and modules. This documentation is necessarily an on-going work-in-progress.
+We also maintain versioned [online API documentation](https://fin-hypergrid.github.io/core/2.1.15/doc/Hypergrid.html) for all public objects and modules. This documentation is necessarily an on-going work-in-progress.
 
 (Cell editor information can be found [here](https://github.com/fin-hypergrid/core/wiki/Cell-Editors).)
 
 (Cell Rendering information can be found [here](https://github.com/fin-hypergrid/core/wiki/Cell-Renderers).)
 
-Hypergrid global configurations can be found [here](https://fin-hypergrid.github.io/core/2.1.14/doc/module-defaults.html).
+Hypergrid global configurations can be found [here](https://fin-hypergrid.github.io/core/2.1.15/doc/module-defaults.html).
 
 ### Roadmap
 

--- a/demo/formatter-workbench/instructions.html
+++ b/demo/formatter-workbench/instructions.html
@@ -173,7 +173,7 @@ Formatting grid cell values is purely a text string manipulation. Any other grap
         <li>Code your localizer referring to examples and the <a href="https://fin-hypergrid.github.io/core/doc/localizerInterface.html" target="localizer-docs">localizer interface</a> documentation.</li>
         <li>Be sure to assign your localizer to <code>module.exports</code>.</li>
         <li>Click the <span class="button">grid.localization.add(…)</span> button.</li>
-        <li><em>Optional:</em> Edit the localizer and click <span class="button">grid.localization.add(…)</span> to update it.</li>
+        <li><em>Optional:</em> Edit the localizer and click <span class="button">grid.localization.add(…)</span> again to update it.</li>
     </ol>
 </div>
 
@@ -299,6 +299,7 @@ For example, here’s a localizer to show a “degrees” unit:
     <ol>
         <li>In the Localizer pane, select the <code>trend</code> localizer.</li>
         <li>Uncomment the <code><i>if</i></code> statement with the <code><i>throw</i></code> statement within it.</li>
+        <li>Click the <span class="button">grid.localization.add(…)</span> button to update it.</li>
         <li>Edit another cell, again setting the contents to some invalid value.</li>
         <li>Press the <strong>enter</strong> key.</li>
         <li>The parser cannot convert the value.</li>

--- a/demo/index.html
+++ b/demo/index.html
@@ -22,7 +22,7 @@
     b = g.behavior,
     m = b.dataModel;">top-level global vars</label>
 
-    <h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.14 dev testbench</h1>
+    <h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.15 dev testbench</h1>
 
     <div id="tabs">
         <div id="tab-dashboard">Dashboard</div>

--- a/demo/js/demo/index.js
+++ b/demo/js/demo/index.js
@@ -42,6 +42,7 @@ window.onload = function() {
             margin: { bottom: '17px', right: '17px'},
             schema: schema,
             plugins: require('fin-hypergrid-event-logger'),
+            // canvasContextAttributes: { alpha: false },
             state: { color: 'orange' }
         },
         grid = new Hypergrid('div#json-example', gridOptions),

--- a/demo/multiple-grids.html
+++ b/demo/multiple-grids.html
@@ -5,7 +5,7 @@
     <style> body > div.hypergrid-container { width: 415px; margin-right: 10px; display: inline-block }</style>
 </head>
 <body>
-<h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.14 multiple grids demo</h1>
+<h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.15 multiple grids demo</h1>
 
 <script src="build/fin-hypergrid.js"></script>
 

--- a/demo/row-props.html
+++ b/demo/row-props.html
@@ -24,7 +24,7 @@
         div#behind {
             position: absolute;
             visibility: hidden;
-            top: 150px;
+            top: 350px;
             left: 150px;
             width: 400px;
             height: 400px;
@@ -33,7 +33,13 @@
             background-color: orange;
         }
         input[type=range] {
-            width: 100px
+            width: 100px;
+            height: 12px
+        }
+        input[type=color] {
+            width: 12px;
+            height: 12px;
+            padding: 0;
         }
     </style>
 </head>
@@ -42,7 +48,7 @@
 
 <div id="controls" class="nowrap">
     <label id="controller" title="Uncheck to hide other controls.">
-        <input type="checkbox" onchange="this.parentElement.parentElement.classList.toggle('nowrap')">
+        <input type="checkbox" onchange="this.parentElement.parentElement.classList.toggle('nowrap');positionBehind()">
         Wrap controls
     </label>
     <div class="radio-group">
@@ -108,34 +114,34 @@ Renders all cells over consolidated row backgrounds, if any. Unsuitable as a cli
     <div class="radio-group">
         Text truncation:
         <label title="grid.properties.truncateTextWithEllipsis = undefined; // can be overridden at a higher level">
-            <input type="radio" name="truncate" onclick="grid.properties.truncateTextWithEllipsis = undefined">
+            <input type="radio" name="truncate" onclick="grid.properties.truncateTextWithEllipsis = undefined; grid.repaint()">
             none
         </label>
         <label title="grid.properties.truncateTextWithEllipsis = true; // can be overridden at a higher level">
-            <input type="radio" name="truncate" onclick="grid.properties.truncateTextWithEllipsis = true" checked>
+            <input type="radio" name="truncate" onclick="grid.properties.truncateTextWithEllipsis = true; grid.repaint()" checked>
             with ellipsis (&hellip;)
         </label>
         <label title="grid.properties.truncateTextWithEllipsis = false; // can be overridden at a higher level">
-            <input type="radio" name="truncate" onclick="grid.properties.truncateTextWithEllipsis = false">
+            <input type="radio" name="truncate" onclick="grid.properties.truncateTextWithEllipsis = false; grid.repaint()">
             <em>before</em> partial char
         </label>
         <label title="grid.properties.truncateTextWithEllipsis = null; // can be overridden at a higher level">
-            <input type="radio" name="truncate" onclick="grid.properties.truncateTextWithEllipsis = null">
+            <input type="radio" name="truncate" onclick="grid.properties.truncateTextWithEllipsis = null; grid.repaint()">
             <em>after</em> partial char
         </label>
     </div>
     <div class="radio-group">
         Clip to:
         <label title="grid.properties.columnClip = true">
-            <input type="radio" name="clipping" onclick="grid.properties.columnClip = true; // can be overridden at column level">
+            <input type="radio" name="clipping" onclick="grid.properties.columnClip = true; grid.repaint()">
             all columns
         </label>
         <label title="grid.properties.columnClip = null">
-            <input type="radio" name="clipping" onclick="grid.properties.columnClip = null; // can be overridden at column level">
+            <input type="radio" name="clipping" onclick="grid.properties.columnClip = null; grid.repaint()">
             last column only
         </label>
         <label title="grid.properties.columnClip = false">
-            <input type="radio" name="clipping" onclick="grid.properties.columnClip = false; // can be overridden at column level" checked>
+            <input type="radio" name="clipping" onclick="grid.properties.columnClip = false; grid.repaint()" checked>
             none
         </label>
     </div>
@@ -218,8 +224,8 @@ Renders all cells over consolidated row backgrounds, if any. Unsuitable as a cli
             translucent blue
         </label>
     </div>
-    <label>
-        <input type="checkbox" onclick="document.querySelector('#behind').style.visibility=this.checked?'visible':'hidden'">
+    <label title="To see through the grid, you must also set grid color to transparent or translucent.">
+        <input type="checkbox" onclick="behindStyle.visibility=this.checked?'visible':'hidden';positionBehind()">
         Behind-the-grid content
     </label>
     <div class="radio-group">
@@ -236,13 +242,48 @@ Renders all cells over consolidated row backgrounds, if any. Unsuitable as a cli
     <label>
         Row height: <input type="range" min="15" max="75" value="34" oninput="nextElementSibling.innerHTML=grid.properties.defaultRowHeight=Number(this.value);grid.behavior.changed()"> (<span>34</span>)
     </label>
+    <div class="radio-group">
+        Horiz. rules:
+        <input type="checkbox" checked oninput="grid.properties.gridLinesH=this.checked;grid.behavior.shapeChanged()">
+        <input type="color" value="brown" onchange="grid.properties.gridLinesHColor=this.value;grid.behavior.shapeChanged()">
+        <input type="range" min="0" max="8" value="1" style="width:24px" oninput="nextElementSibling.innerHTML=grid.properties.gridLinesHWidth=Number(this.value);grid.behavior.shapeChanged()"> (<span>1</span>)
+        Vert. rules:
+        <input type="checkbox" checked oninput="grid.properties.gridLinesV=this.checked;grid.behavior.shapeChanged()">
+        <input type="color" value="brown" onchange="grid.properties.gridLinesVColor=this.value;grid.behavior.shapeChanged()">
+        <input type="range" min="0" max="8" value="1" style="width:24px" oninput="nextElementSibling.innerHTML=grid.properties.gridLinesVWidth=Number(this.value);grid.behavior.shapeChanged()"> (<span>1</span>)
+        Box model:
+        <label title="grid.properties.backgroundColor='white'">
+            <input type="radio" name="box-sizing" value="border-box" onclick="grid.properties.boxSizing=this.value;grid.behavior.shapeChanged()" checked>
+            border-box
+        </label>
+        <label title="grid.properties.backgroundColor='transparent'">
+            <input type="radio" name="box-sizing" value="content-box" onclick="grid.properties.boxSizing=this.value;grid.behavior.shapeChanged()">
+            content-box
+        </label>
+    </div>
+    <label>
+        Fixed columns:
+        <input type="range" min="0" max="4" value="0" style="width:24px" oninput="nextElementSibling.innerHTML=grid.properties.fixedColumnCount=Number(this.value);grid.behavior.shapeChanged()"> (<span>0</span>)
+        Fixed rows:
+        <input type="range" min="0" max="11" value="0" style="width:24px" oninput="nextElementSibling.innerHTML=grid.properties.fixedRowCount=Number(this.value);grid.behavior.shapeChanged()"> (<span>0</span>)
+    </label>
+    <label>
+        Horiz. divider:
+        <input type="color" value="#a4a4a4" onchange="grid.properties.fixedLinesHColor=this.value;grid.behavior.shapeChanged()">
+        <input type="range" min="0" max="12" value="1" style="width:24px" oninput="nextElementSibling.innerHTML=grid.properties.fixedLinesHWidth=Number(this.value);grid.behavior.shapeChanged()"> (<span>1</span>)
+        edge: <input type="range" min="0" max="5" value="0" style="width:22px" oninput="nextElementSibling.innerHTML=grid.properties.fixedLinesHEdge=Number(this.value);grid.behavior.shapeChanged()"> (<span>0</span>)
+        Vert. divider:
+        <input type="color" value="#a4a4a4" onchange="grid.properties.fixedLinesVColor=this.value;grid.behavior.shapeChanged()">
+        <input type="range" min="0" max="12" value="1" style="width:24px" oninput="nextElementSibling.innerHTML=grid.properties.fixedLinesVWidth=Number(this.value);grid.behavior.shapeChanged()"> (<span>1</span>)
+        edge: <input type="range" min="0" max="5" value="0" style="width:22px" oninput="nextElementSibling.innerHTML=grid.properties.fixedLinesVEdge=Number(this.value);grid.behavior.shapeChanged()"> (<span>0</span>)
+    </label>
     <label>
         Columns:   <input type="range" id="COLUMNS"   title="" min="1"  max="100" oninput="fixAll()"> (<span></span>) &nbsp;
         Rows:      <input type="range" id="ROWS"      title="" min="10" max="9999" step="10" oninput="fixAll()"> (<span></span>) &nbsp;
-        Precision: <input type="range" id="PRECISION" title="Number of digits." min="1"  max="30" oninput="fixAll()"> (<span></span>) &nbsp;
-        Scale:     <input type="range" id="SCALE"     title="Number of digits to right of decimal point." min="0"  max="10" oninput="fixAll()"> (<span></span>) &nbsp;
-        <input type="button" value="Reset Data" onclick="init()">
-        <input type="button" value="Benchmark Data" onclick="benchmark()">
+        Precision: <input type="range" id="PRECISION" title="Number of digits." min="1"  max="30" style="width:29px" oninput="fixAll()"> (<span></span>) &nbsp;
+        Scale:     <input type="range" id="SCALE"     title="Number of digits to right of decimal point." min="0"  max="10" style="width:10px" oninput="fixAll()"> (<span></span>) &nbsp;
+        <input type="button" value="Reset Data" title="Recreate data using slider values." onclick="init()">
+        <input type="button" value="Benchmark Data" title="Set sliders to 100, 9999, 5, 2 and recreate data" onclick="benchmark()">
     </label>
 </div>
 
@@ -253,6 +294,8 @@ Renders all cells over consolidated row backgrounds, if any. Unsuitable as a cli
     <script>
 
 var grid = new fin.Hypergrid();
+var behindStyle = document.querySelector('#behind').style;
+function positionBehind() { behindStyle.top=Math.ceil(grid.canvas.canvas.getBoundingClientRect().top) + 100 + 'px'; }
 
 var COLUMNS = 12;
 var ROWS = 9999;
@@ -317,7 +360,7 @@ grid.addProperties({
     columnClip: false,
     defaultRowHeight: 34,
     editor: 'textfield',
-//    showRowNumbers: false,
+    rowHeaderCheckboxes: false,
     rowHeaderColor: 'brown',
     lineColor: 'brown',
     renderFalsy: true,
@@ -391,6 +434,7 @@ function logBundlesToConsole() {
 }
 
 function setBackgroundColor(backgroundColor) {
+    grid.repaint();
     grid.properties.backgroundColor = backgroundColor;
     rebundle();
 }
@@ -538,7 +582,7 @@ function change() {
 function simulate(checked) {
     var paintRadioButtons = document.querySelectorAll('[name=paint]'),
         paintOnFlagSetRadioButton = paintRadioButtons[0],
-        paintBlastRadioButton = paintRadioButtons[2]
+        paintBlastRadioButton = paintRadioButtons[2],
         paintBlastLabel = paintBlastRadioButton.parentElement;
 
     if (!checked && paintBlastRadioButton.checked) {

--- a/demo/row-props.html
+++ b/demo/row-props.html
@@ -38,7 +38,7 @@
     </style>
 </head>
 <body>
-<h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.14 performance workbench</h1>
+<h1 style="margin:.5em; color:lightgrey">Hypergrid 2.1.15 performance workbench</h1>
 
 <div id="controls" class="nowrap">
     <label id="controller" title="Uncheck to hide other controls.">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fin-hypergrid",
-  "version": "2.1.14",
+  "version": "2.1.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fin-hypergrid",
-  "version": "2.1.14",
+  "version": "2.1.15",
   "description": "Canvas-based high-performance grid",
   "repository": {
     "type": "git",

--- a/src/Hypergrid.js
+++ b/src/Hypergrid.js
@@ -203,7 +203,7 @@ var Hypergrid = Base.extend('Hypergrid', {
     terminate: function() {
         document.removeEventListener('mousedown', this.mouseCatcher);
         this.canvas.stop();
-        Hypergrid.grids.splice(this.grids.indexOf(this), 1);
+        Hypergrid.grids.splice(Hypergrid.grids.indexOf(this), 1);
     },
 
 

--- a/src/Hypergrid.js
+++ b/src/Hypergrid.js
@@ -32,7 +32,34 @@ var EDGE_STYLES = ['top', 'bottom', 'left', 'right'],
  * @mixes themes.mixin
  * @mixes themes.sharedMixin
  * @constructor
- * @param {string|Element} [container] - CSS selector or Element
+ * @classdesc An object representing a Hypergrid.
+ * @desc The first parameter, `container`, is optional. If omitted, the `options` parameter is promoted to first position. (Note that the container can also be given in `options.container.`)
+ * #### `options.canvasContextAttributes` object (see below)
+ * The only currently meaningful property of this object is `alpha`:
+ *
+ * ```js
+ * var gridOptions = {
+ *     canvasContextAttributes: { alpha: false }
+ * };
+ * var myGrid = new Hypergrid(gridOptions);
+ * ```
+ *
+ * `alpha` is a boolean that indicates if the canvas contains an alpha channel. If set to `false`, the browser now knows that the backdrop is always opaque, which can speed up drawing of transparent content and images.
+ *
+ * This option was added by request although testing failed to show any measurable performance benefit.
+ *
+ * Use with caution. In particular, if the canvas is set to "opaque" (`{alpha: false}`), do _not_ also specify a transparent or translucent color for `grid.properties.backGround` because content may then be drawn with corrupt anti-aliasing (at lest in Chrome v67).
+ *
+ * Note that such an "opaque" canvas can still be made to appear translucent using the CSS `opacity` property — a different effect entirely.
+ *
+ * Although this option has no apparent performance gains (in Chrome v63), it does permit the graphics context to use [sub-pixel rendering](https://en.wikipedia.org/wiki/Subpixel_rendering) for sharper text as viewed on LCD or LED screens, especially black text on white backgrounds, and especially when viewed on a high-pixel-density display such as an [Apple retina display](https://en.wikipedia.org/wiki/Retina_Display).
+ *
+ * value | Canvas | Text | Sample
+ * ----- | :----: | :--: | ------
+ * `{ alpha: true } ` | transparent | regular<br>anti-aliasing | ![regular.png](https://cdn-pro.dprcdn.net/files/acc_645730/ZqurK3)
+ * `{ alpha: false }` | opaque | sub-pixel<br>rendering | ![sub-pixel.png](https://cdn-std.dprcdn.net/files/acc_645730/bf3VXh)
+ *
+ * @param {string|Element} [container] - CSS selector or Element. If omitted, Hypergrid first looks for an _empty_ element with an ID of `hypergrid`. If not found, it will create a new element. In either case, the container element has the class name `hypergrid-container` added to its class name list. Finally, if the there is more than one such element with that class name, the element's ID attribute is set to `hypergrid` + _n_ where n is an ordinal one less than the number of such elements.
  * @param {object} [options]
  * @param {function} [options.Behavior=behaviors.JSON] - A grid behavior constructor (extended from {@link Behavior}).
  * @param {function[]} [options.pipeline] - A list function constructors to use for passing data through a series of transforms to occur on reindex call
@@ -52,10 +79,12 @@ var EDGE_STYLES = ['top', 'bottom', 'left', 'right'],
  *
  * @param {string|Element} [options.container] - CSS selector or Element
  *
+ * @param {object} [options.canvasContextAttributes] - Passed to [`HTMLCanvasElement.getContext`](https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/getContext). _Please see discussion above._
+ *
  * @param {string} [options.localization=Hypergrid.localization]
- * @param {string|string[]} [options.localization.locale=Hypergrid.localization.locale] - The default locale to use when an explicit `locale` is omitted from localizer constructor calls. Passed to Intl.NumberFomrat` and `Intl.DateFomrat`. See {@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation|Locale identification and negotiation} for more information.
- * @param {string} [options.localization.numberOptions=Hypergrid.localization.numberOptions] - Options passed to `Intl.NumberFormat` for creating the basic "number" localizer.
- * @param {string} [options.localization.dateOptions=Hypergrid.localization.dateOptions] - Options passed to `Intl.DateFomrat` for creating the basic "date" localizer.
+ * @param {string|string[]} [options.localization.locale=Hypergrid.localization.locale] - The default locale to use when an explicit `locale` is omitted from localizer constructor calls. Passed to Intl.NumberFomrat` and `Intl.DateFomrat`. See {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation|Locale identification and negotiation} for more information.
+ * @param {string} [options.localization.numberOptions=Hypergrid.localization.numberOptions] - Options passed to [`Intl.NumberFormat`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat) for creating the basic "number" localizer.
+ * @param {string} [options.localization.dateOptions=Hypergrid.localization.dateOptions] - Options passed to [`Intl.DateTimeFormat`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat) for creating the basic "date" localizer.
  *
  * @param {object} [options.schema]
  *
@@ -126,7 +155,7 @@ var Hypergrid = Base.extend('Hypergrid', {
         this.cellEditors = Object.create(cellEditors);
         Object.defineProperty(this.cellEditors, 'create', { value: createCellEditor.bind(this) });
 
-        this.initCanvas();
+        this.initCanvas(options.canvasContextAttributes);
 
         if (this.options.Behavior) {
             this.setBehavior(this.options); // also sets this.options.pipeline and this.options.data
@@ -1048,7 +1077,7 @@ var Hypergrid = Base.extend('Hypergrid', {
      * @summary Initialize drawing surface.
      * @private
      */
-    initCanvas: function() {
+    initCanvas: function(contextAttributes) {
         if (!this.divCanvas) {
             var divCanvas = document.createElement('div');
 
@@ -1056,7 +1085,7 @@ var Hypergrid = Base.extend('Hypergrid', {
 
             this.div.appendChild(divCanvas);
 
-            var canvas = new Canvas(divCanvas, this.renderer, this.options.canvas);
+            var canvas = new Canvas(divCanvas, this.renderer, contextAttributes);
             canvas.canvas.classList.add('hypergrid');
 
             this.divCanvas = divCanvas;

--- a/src/features/ColumnMoving.js
+++ b/src/features/ColumnMoving.js
@@ -99,7 +99,7 @@ var ColumnMoving = Feature.extend('ColumnMoving', {
             dragger.style.position = 'fixed';
 
             document.body.appendChild(dragger);
-            draggerCTX = dragger.getContext('2d');
+            draggerCTX = dragger.getContext('2d', { alpha: false });
         }
         if (!floatColumn) {
             floatColumn = document.createElement('canvas');
@@ -108,7 +108,7 @@ var ColumnMoving = Feature.extend('ColumnMoving', {
             floatColumn.style.position = 'fixed';
 
             document.body.appendChild(floatColumn);
-            floatColumnCTX = floatColumn.getContext('2d');
+            floatColumnCTX = floatColumn.getContext('2d', { alpha: false });
         }
 
     },

--- a/src/lib/Canvas.js
+++ b/src/lib/Canvas.js
@@ -792,7 +792,7 @@ function makeCharMap() {
 }
 
 function getCachedContext(canvasElement, type) {
-    var gc = canvasElement.getContext(type || '2d'),
+    var gc = canvasElement.getContext(type || '2d', { alpha: false }),
         props = {},
         values = {};
 

--- a/src/lib/Canvas.js
+++ b/src/lib/Canvas.js
@@ -22,7 +22,7 @@ var RESIZE_POLLING_INTERVAL = 200,
     resizeInterval,
     charMap = makeCharMap();
 
-function Canvas(div, component) {
+function Canvas(div, component, contextAttributes) {
     var self = this;
 
     // create the containing <div>...</div>
@@ -37,8 +37,8 @@ function Canvas(div, component) {
     this.div.appendChild(this.infoDiv);
 
     // create and append the canvas
-    this.gc = getCachedContext(this.canvas = document.createElement('canvas'));
-    this.bc = getCachedContext(this.buffer = document.createElement('canvas'));
+    this.gc = getCachedContext(this.canvas = document.createElement('canvas'), contextAttributes);
+    this.bc = getCachedContext(this.buffer = document.createElement('canvas'), contextAttributes);
 
     this.div.appendChild(this.canvas);
 
@@ -791,8 +791,8 @@ function makeCharMap() {
     return map;
 }
 
-function getCachedContext(canvasElement, type) {
-    var gc = canvasElement.getContext(type || '2d', { alpha: false }),
+function getCachedContext(canvasElement, contextAttributes) {
+    var gc = canvasElement.getContext('2d', contextAttributes),
         props = {},
         values = {};
 

--- a/src/renderer/by-cells.js
+++ b/src/renderer/by-cells.js
@@ -81,6 +81,10 @@ function paintCellsAsNeeded(gc) {
     }.bind(this));
 
     // gc.clipRestore(clipToGrid);
+
+    if (this.grid.properties.boxSizing === 'border-box') {
+        this.paintGridlines(gc);
+    }
 }
 
 paintCellsAsNeeded.key = 'by-cells';

--- a/src/renderer/by-columns.js
+++ b/src/renderer/by-columns.js
@@ -7,7 +7,7 @@ var bundleColumns = require('./bundle-columns');
  *
  * First, a background rect is drawn using the grid background color.
  *
- * Then, if there are any columns with their own background color _that differs from the grid background color,_ these are consolidated and the consolidated groups of column backgrounds are all drawn before iterating through cells. Note that these column rects are _not_ suitable for clipping overflow text from previous columns. If you have overflow text, either turn on clipping (big performance hit) or turn on one of the `truncateTextWithEllipsis` options.
+ * Then, if there are any columns with their own background color _that differs from the grid background color,_ these are consolidated and the consolidated groups of column backgrounds are all drawn before iterating through cells. Note that these column rects are _not_ suitable for clipping overflow text from previous columns. If you have overflow text, either turn on clipping (`grid.properties.columnClip = true` but big performance hit) or turn on one of the `truncateTextWithEllipsis` options.
  *
  * `try...catch` surrounds each cell paint in case a cell renderer throws an error.
  * The error message is error-logged to console AND displayed in cell.


### PR DESCRIPTION
## Synopsis

1. Fix partial render grid lines (Issue #730)
2. Option to turn off canvas's alpha channel
3. Fix error in `Hypgrid.prototype.terminate`
4. Add more dashboard controls to `demo/row-props.html`
5. Add `autosizeGroups` and documentation to `fin-hypergrid-grouped-header-plugin`

### 1. Fix partial renderer grid lines (Issue #730)

This issue affects the "partial renderer" only. The partial render is the "by-cells" grid renderer, which is the "difference engine" renderer that only repaints cells whose contents has changed. This renderer has the major advantage of speed, up to 5x faster (!).

The issue was that the cells were overwriting the lines previously drawn by the key frame render. This is because in the default "boxSizing" mode (`grid.properties.boxSizing = 'border-box'`), cell contents _includes_ the one-pixel borders.

The fix was to redraw the grid lines in this situation, which incurs a negligible performance hit. You can however avoid this by setting `.boxSizing = 'content-box'` (which has some other advantages besides).

You can play with the box-sizing modes as well as the grid line widths using the new dashboard controls in the `row-props.html` app. (See item **4** below.)

### 2. Option to turn off canvas's alpha channel

Hypergrid intentionally supports transparent/translucent grids, for example:
```js
grid.properties.backgroundColor = 'transparent'; grid.repaint();
grid.properties.backgroundColor = 'rgba(0,0,0,0)'; grid.repaint();
grid.properties.backgroundColor = 'rgba(200,0,0,.5)'; grid.repaint();
```

The use case for a transparent or translucent grid is rare, however, so we are introducing a new grid instantiation option for v2.1.15 and v3.0.0: `options.canvasContextAttributes` a value that will be passed to [`HTMLCanvasElement.getContext`](https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/getContext):

```js
var gridOptions = {
    canvasContextAttributes: { alpha: false }
};
var myGrid = new Hypergrid(gridOptions);
```

The only "context attribute" currently available is `alpha`:

> Boolean that indicates if the canvas contains an alpha channel. If set to `false`, the browser now knows that the backdrop is always opaque, which can speed up drawing of transparent content and images.

Use with caution. In particular, if the canvas is set to "opaque" (`{alpha: false}`), do _not_ also specify a transparent or translucent color for `grid.properties.backGround` because content may then be drawn with corrupt anti-aliasing (at lest in Chrome v67).

Note that such an "opaque" canvas can still be made to appear translucent using the CSS `opacity` property — a different effect entirely.

Although `alpha: false` has no apparent performance gains (in Chrome v63), it does permit the graphics context to use [sub-pixel rendering](https://en.wikipedia.org/wiki/Subpixel_rendering) for sharper text when viewed on LCD or LED screens, in especially black text on white backgrounds. The improvement is particularly apparent when viewed on a high-pixel-density display (such as an [Apple retina display](https://en.wikipedia.org/wiki/Retina_Display)).

`canvasContextAttributes` | Canvas | Text | Sample
:-: | :-: | :-: | :-:
`alpha: true` | transparent | regular<br>anti-aliasing | ![regular.png](https://cdn-pro.dprcdn.net/files/acc_645730/ZqurK3)
`alpha: false` | opaque | sub-pixel<br>rendering | ![sub-pixel.png](https://cdn-std.dprcdn.net/files/acc_645730/bf3VXh)

### 3. Fix error in `Hypgrid.prototype.terminate`
Fixed a coding error in the `terminate` method, which now functions correctly: The shared property `Hypergrid.grids` maintains a list of instantiated grids. Use `grid.terminate()` to remove a grid from the list before deleting it's canvas element.

### 4. Add more dashboard controls to [`demo/row-props.html`](https://fin-hypergrid.github.io/core/2.1.15/row-props.html)
* New controls:
   * Rule lines
      * Horizontal (between rows)
         * enable (`gridLinesH`)
         * color (`gridLinesHColor`)
         * width (`gridLinesHWidth`)
      * Vertical (between columns)
         * enable (`gridLinesV`)
         * color (`gridLinesVColor`)
         * width (`gridLinesVWidth`)
   * Divider rule lines
      * Horizontal (between column headers or fixed rows and the scrolling content)
         * color (`fixedLinesHColor`)
         * width (`fixedLinesHWidth`)
         * edge (`fixedLinesHEdge`)
      * Vertical (between row headers or fixed columns and the scrolling content)
         * color (`fixedLinesVColor`)
         * width (`fixedLinesVWidth`)
         * edge (`fixedLinesVEdge`)
   * Fixed row count (`fixedRowCount`)
   * Fixed column count (`fixedColumnCount`)
   * Cell "box sizing" (`box-sizing`)
* Added missing `repaint()` calls to some controls.
* Reposition "behind-the-grid content" (orange circle) relative to grid to accommodate wrapped controls.

### 5. Add `autosizeGroups` and documentation to `fin-hypergrid-grouped-header-plugin`
Though technically not a part of Hypergrid core, it is worth noting here that [`fin-hypergrid-grouped-header-plugin`](https://github.com/fin-hypergrid/grouped-header-plugin) has been updated to version `1.2.0`.
* Add `autosizeGroups` property (_default:_ `true`) — see README
* Rewrote [`README.md`](https://github.com/fin-hypergrid/grouped-header-plugin/blob/master/README.md). _(The original README content w/examples was unfortunately lost some time back.)_
* Published to [nmpjs.org](https://www.npmjs.com/package/fin-hypergrid-grouped-header-plugin). _(Note however the version of the README found here has some minor errors & omissions.)_
* Published to [CDN](https://fin-hypergrid.github.io/grouped-header-plugin).