### PR TITLE
Hypergrid v3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 **fin-hypergrid** is an ultra-fast HTML5 grid presentation layer, achieving its speed by rendering (in a canvas tag) only the currently visible portion of your (virtual) grid, thus avoiding the latency and life-cycle issues of building, walking, and maintaining a complex DOM structure. Please be sure to checkout our [design overview](OVERVIEW.md)
 
 Below is an example custom application built on top of the Hypergrid API tooling.
-It also highlights a DOM-based custom external editor triggered via hypergrid events as well as interaction with Hypergrid's column ordering API
+It also highlights a DOM-based custom external editor triggered via hypergrid events as well as interaction with Hypergrid’s column ordering API.
 
 <img src="images/README/gridshot04.gif">
 
@@ -15,9 +15,9 @@ It also highlights a DOM-based custom external editor triggered via hypergrid ev
 * [Roadmap](#roadmap)
 * [Contributing](#contributors)
 
-### Current Release (3.0.3 - 25 September 2018)
+### Current Release (3.1.0 - 29 September 2018)
 
-**Hypergrid 3.0 includes a revised data model with some breaking changes.**
+**Hypergrid 3.1 includes 3.0’s revised data model with some breaking changes.**
 
 _For a complete list of changes, see the [release notes](https://github.com/fin-hypergrid/core/releases)._
 
@@ -25,7 +25,7 @@ _For a complete list of changes, see the [release notes](https://github.com/fin-
 
 #### npm module _(recommended)_
 Published as a CommonJS module to npmjs.org.
-Specify a <a href="https://semver.org/">SEMVER</a> of `"fin-hypergrid": "3.0.3"` (or `"^3.0.3"`) in your package.json file,
+Specify a <a href="https://semver.org/">SEMVER</a> of `"fin-hypergrid": "3.1.0"` (or `"^3.1.0"`) in your package.json file,
 issue the `npm install` command, and let your bundler (<a target="webpack" href="https://webpack.js.org/">wepback</a>,
 <a target="browserify" href="http://browserify.org/">Browserify</a>) create a single file containing both Hypergrid and your application.
 
@@ -69,7 +69,7 @@ The [Perspective](https://github.com/jpmorganchase/perspective) open source proj
 
 ##### AdaptableBlotter.JS
 
-[Openfin](http://openfin.co)'s AdaptableBlotter.JS ([installer](https://install.openfin.co/download/?fileName=adaptable_blotter_openfin&config=http://beta.adaptableblotter.com/app-beta.json)) is a demo app that shows the capabilities of both Openfin and Hypergrid.
+[Openfin](http://openfin.co)’s AdaptableBlotter.JS ([installer](https://install.openfin.co/download/?fileName=adaptable_blotter_openfin&config=http://beta.adaptableblotter.com/app-beta.json)) is a demo app that shows the capabilities of both Openfin and Hypergrid.
 
 ![](images/README/partner-adaptableblotter_image-01@2x-667x375@2x.png)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fin-hypergrid",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "description": "Canvas-based high-performance grid",
   "main": "src/Hypergrid",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "datasaur-base": "^3.0.0",
     "datasaur-local": "^3.0.0",
     "extend-me": "^2.7.0",
-    "finbars": "^1.6.1",
+    "finbars": "^1.6.2",
     "inject-stylesheet-template": "^1.0.1",
     "mustache": "^2.3.0",
     "object-iterators": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "datasaur-base": "^3.0.0",
     "datasaur-local": "^3.0.0",
     "extend-me": "^2.7.0",
-    "finbars": "^1.6.2",
+    "finbars": "^2.0.0",
     "inject-stylesheet-template": "^1.0.1",
     "mustache": "^2.3.0",
     "object-iterators": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "datasaur-base": "^3.0.0",
     "datasaur-local": "^3.0.0",
     "extend-me": "^2.7.0",
-    "finbars": "^1.6.0",
+    "finbars": "^1.6.1",
     "inject-stylesheet-template": "^1.0.1",
     "mustache": "^2.3.0",
     "object-iterators": "1.3.0",

--- a/src/Hypergrid/modules.js
+++ b/src/Hypergrid/modules.js
@@ -26,6 +26,7 @@ Object.defineProperties(module.exports, {
     'datasaur-base': { value: require('datasaur-base') }, // may be removed in a future release
     'datasaur-local': { value: require('datasaur-local') }, // may be removed in a future release
     'extend-me': {value: require('extend-me') },
+    finbars: { value: require('finbars') },
     'object-iterators': { value: require('object-iterators') },
     overrider: { value: require('overrider') },
     rectangular: { value: require('rectangular') },

--- a/src/behaviors/Column.js
+++ b/src/behaviors/Column.js
@@ -188,7 +188,7 @@ Column.prototype = {
     },
 
     setWidth: function(width) {
-        width = Math.max(this.properties.minimumColumnWidth, width);
+        width = Math.min(Math.max(this.properties.minimumColumnWidth, width), this.properties.maximumColumnWidth || Infinity);
         if (width !== this.properties.width) {
             this.properties.width = width;
             this.properties.columnAutosizing = false;

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -748,6 +748,8 @@ var defaults = {
     defaultRowHeight: version > 2 ? 14 : 15,
 
     /**
+     * This default column width is used when `width` property is undefined.
+     * (`width` is defined on column creation unless {@link module:defaults.columnAutosizing columnAutosizing} has been set to `false`.)
      * @default
      * @type {number}
      * @memberOf module:defaults
@@ -755,11 +757,27 @@ var defaults = {
     defaultColumnWidth: 100,
 
     /**
+     * Minimum column width.
+     * Adjust this value for different fonts/sizes or exotic cell renderers.
+     * _Must be defined._
+     * The default (`5`) is enough room for an ellipsis with default font size.
      * @default
      * @type {number}
      * @memberOf module:defaults
      */
     minimumColumnWidth: 5,
+
+    /**
+     * Maximum column width.
+     * _When defined,_ column width is clamped to this value by {@link Column#setWidth setWidth}).
+     * Ignored when falsy.
+     * Respects {@link module:defaults.resizeColumnInPlace resizeColumnInPlace} but may cause user confusion when
+     * user can't make column narrower due to next column having reached its maximum.
+     * @default
+     * @type {number}
+     * @memberOf module:defaults
+     */
+    maximumColumnWidth: undefined,
 
     /**
      * Resizing a column through the UI (by clicking and dragging on the column's
@@ -769,12 +787,12 @@ var defaults = {
      * In other words, if user expands (say) the third column, then the fourth column will contract —
      * and _vice versa_ — without therefore affecting the width of the grid.
      *
-     * This is a _column propert_ and may be set for selected columns (`myColumn.properties.resizeColumnInPlace`)
-     * or for all columns by setting it at the grid level. (`myGrid.properties.resizeColumnInPlace`).
+     * This is a _column property_ and may be set for selected columns (`myColumn.properties.resizeColumnInPlace`)
+     * or for all columns by setting it at the grid level (`myGrid.properties.resizeColumnInPlace`).
      *
      * Note that the implementation of this property does not allow expanding a
      * column beyond the width it can borrow from the next column.
-     * The last column, however, is unconstrained and resizing it will affect the total grid width.
+     * The last column, however, is unconstrained, and resizing of course affects the total grid width.
      * @default
      * @type {boolean}
      * @memberOf module:defaults

--- a/src/features/ColumnResizing.js
+++ b/src/features/ColumnResizing.js
@@ -63,17 +63,23 @@ var ColumnResizing = Feature.extend('ColumnResizing', {
      */
     handleMouseDrag: function(grid, event) {
         if (this.dragColumn) {
-            var delta = this.getMouseValue(event) - this.dragStart;
-            var dragWidth = this.dragStartWidth + delta;
-            if (!this.nextColumn) {
+            var delta = this.getMouseValue(event) - this.dragStart,
+                dragWidth = this.dragStartWidth + delta,
+                nextWidth = this.nextStartWidth - delta;
+            if (!this.nextColumn) { // nextColumn et al instance vars defined when resizeColumnInPlace (by handleMouseDown)
                 grid.behavior.setColumnWidth(this.dragColumn, dragWidth);
-            } else if (
-                0 < delta && delta <= (this.nextStartWidth - this.nextColumn.properties.minimumColumnWidth) ||
-                0 > delta && delta >= -(this.dragStartWidth - this.dragColumn.properties.minimumColumnWidth)
-            ) {
-                var nextWidth = this.nextStartWidth - delta;
-                grid.behavior.setColumnWidth(this.dragColumn, dragWidth);
-                grid.behavior.setColumnWidth(this.nextColumn, nextWidth);
+            } else {
+                var np = this.nextColumn.properties, dp = this.dragColumn.properties;
+                if (
+                    0 < delta && delta <= (this.nextStartWidth - np.minimumColumnWidth) &&
+                    (!dp.maximumColumnWidth || dragWidth <= dp.maximumColumnWidth)
+                    ||
+                    0 > delta && delta >= -(this.dragStartWidth - dp.minimumColumnWidth) &&
+                    (!np.maximumColumnWidth || nextWidth < np.maximumColumnWidth)
+                ) {
+                    grid.behavior.setColumnWidth(this.dragColumn, dragWidth);
+                    grid.behavior.setColumnWidth(this.nextColumn, nextWidth);
+                }
             }
         } else if (this.next) {
             this.next.handleMouseDrag(grid, event);

--- a/src/lib/SelectionModel.js
+++ b/src/lib/SelectionModel.js
@@ -444,11 +444,10 @@ SelectionModel.prototype = {
      */
     getSelectedRows: function() {
         if (this.areAllRowsSelected()) {
-            var headerRows = this.grid.getHeaderRowCount();
-            var rowCount = this.grid.getRowCount() - headerRows;
+            var rowCount = this.grid.getRowCount();
             var result = new Array(rowCount);
             for (var i = 0; i < rowCount; i++) {
-                result[i] = i + headerRows;
+                result[i] = i;
             }
             return result;
         }

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -613,8 +613,8 @@ var Renderer = Base.extend('Renderer', {
             return;
         }
 
-        var vci = this.visibleColumnsByIndex,
-            vri = this.visibleRowsByDataRowIndex,
+        var vc, vci = this.visibleColumnsByIndex,
+            vr, vri = this.visibleRowsByDataRowIndex,
             lastScrollableColumn = this.visibleColumns[this.visibleColumns.length - 1], // last column in scrollable section
             lastScrollableRow = this.visibleRows[this.visibleRows.length - 1], // last row in scrollable data section
             firstScrollableColumn = vci[this.dataWindow.origin.x],
@@ -625,25 +625,33 @@ var Renderer = Base.extend('Renderer', {
 
         if (
             // entire selection scrolled out of view to left of visible columns; or
-            selection.corner.x < this.visibleColumns[0].columnIndex ||
+            (vc = this.visibleColumns[0]) &&
+            selection.corner.x < vc.columnIndex ||
 
             // entire selection scrolled out of view between fixed columns and scrollable columns; or
             fixedColumnCount &&
-            selection.origin.x > this.visibleColumns[fixedColumnCount - 1].columnIndex &&
+            firstScrollableColumn &&
+            (vc = this.visibleColumns[fixedColumnCount - 1]) &&
+            selection.origin.x > vc.columnIndex &&
             selection.corner.x < firstScrollableColumn.columnIndex ||
 
             // entire selection scrolled out of view to right of visible columns; or
+            lastScrollableColumn &&
             selection.origin.x > lastScrollableColumn.columnIndex ||
 
             // entire selection scrolled out of view above visible rows; or
-            selection.corner.y < this.visibleRows[headerRowCount].rowIndex ||
+            (vr = this.visibleRows[headerRowCount]) &&
+            selection.corner.y < vr.rowIndex ||
 
             // entire selection scrolled out of view between fixed rows and scrollable rows; or
             fixedRowCount &&
-            selection.origin.y > this.visibleRows[headerRowCount + fixedRowCount - 1].rowIndex &&
+            firstScrollableRow &&
+            (vr = this.visibleRows[headerRowCount + fixedRowCount - 1]) &&
+            selection.origin.y > vr.rowIndex &&
             selection.corner.y < firstScrollableRow.rowIndex ||
 
             // entire selection scrolled out of view below visible rows
+            lastScrollableRow &&
             selection.origin.y > lastScrollableRow.rowIndex
         ) {
             return;
@@ -653,6 +661,10 @@ var Renderer = Base.extend('Renderer', {
             vrOrigin = vri[selection.origin.y] || firstScrollableRow,
             vcCorner = vci[selection.corner.x] || (selection.corner.x > lastScrollableColumn.columnIndex ? lastScrollableColumn : vci[fixedColumnCount - 1]),
             vrCorner = vri[selection.corner.y] || (selection.corner.y > lastScrollableRow.rowIndex ? lastScrollableRow : vri[fixedRowCount - 1]);
+
+        if (!(vcOrigin && vrOrigin && vcCorner && vrCorner)) {
+            return;
+        }
 
         // Render the selection model around the bounds
         var config = {


### PR DESCRIPTION
### Minor version update
This is a "minor version update" which is interface-backwards-compatible with v3.0.* but introduces a new feature, the `maximumColumnWidth` prop _(see below)._

> NOTE: Although the merge branch is called `v3.0.4` the version has been bumped to `3.1.0`.

This release also contains:
* Bug fixes
* Simplified license
* Improved tutorial (still a WIP though)

### Synopsis
1. Fix bug in `getSelectedRows` 
2. `renderLastSelection` now bails on missing rows
3. Update keys down array when shift key changes
4. Update keys down array whenever referenced by mouse event handlers
5. Implement `maximumColumnWidth` prop
6. Capture off-grid `mouseup` during scrollbar thumb drag
7. Retain scrollbar thumb's `.hover` CSS class throughout drag
8. Normalize mouse wheel metrics across platforms and browsers
9. Better dates in dev testbench data
10. Fix jsdocs type: `options.contextAttributes`
11. Reorganize and update the Tutorial
12. Updated copyright notice
13. Updated license

### 1. Fix `getSelectedRows` \[bug]
When  all rows selected, `SelectionModel.prototype.getSelectedRows` returns inaccurate list. Addresses Issue #764 (_see_). 

### 2. `renderLastSelection` now bails on missing rows \[bug]
When the selection included rows that are now missing, `Renderer.prototype.renderLastSelection` previously threw an error. It now aborts without rendering.

### 3. Update keys down array when shift key changes \[bug]
Addresses Issue #770 (_see_).

### 4. Update keys down array whenever referenced by mouse event handlers \[bug]
Addresses Issue #769 (_see_).

### 5. Implement `maximumColumnWidth` prop \[new feature]
Addresses Issue #761 (_see_). This is a new feature, hence the minor version number bump (`3.1.0`).

### 6. Capture off-grid `mouseup` during scrollbar thumb drag \[enhancement]
Addresses `finbars` [Issue #6](https://github.com/fin-hypergrid/finbars/issues/6) (_see_) into Hypergrid.

### 7. Retain scrollbar thumb's `.hover` CSS class throughout drag \[enhancement]
Merges `finbars` [Issue #7](https://github.com/fin-hypergrid/finbars/issues/7) (_see_) into Hypergrid.

### 8. Normalize mouse wheel metrics across platforms and browsers \[enhancement]
The following platforms and browsers are supported by assigning multiplicative factors to each (webkit on macOS = 1.0):
* macOS
   * webkit (Chrome/Safari/Opera)
   * moz (Firefox)
* Windows
   * webkit (Chrome/Opera)
   * moz (Firefox)
   * IE 11
   * Edge

Measurements were taken with default wheel system settings. The macOS measurements were taken on 10.13.6 (High Sierra). The Windows measurements were taken on Windows 10 and Windows 7 SP 1 (which yielded identical results with the exception of IE 11 on W7 which was ~20% faster compared to to IE11 on W10 but not enough to be a concern, especially with < 1% [browser market share](http://gs.statcounter.com)).

Normalization can be turned off:
* Before instantiation:
   ```js
   var FinBar = require('finbars'); // or Hypegrid.modules.finbars or fin.Hypergrid.require('finbars')
   delete FinBar.normals;
   ```
* For a specific grid instance:
   ```js
   grid.sbVScroller.normal = grid.sbHScroller.normal = 1;
   ```

In any case (with or without normalization), the application layer can still apply its own (additional) factor using [`grid.properties.wheelVFactor`](https://fin-hypergrid.github.io/core/doc/module-defaults.html#.wheelVFactor) and [`grid.properties.wheelHFactor`](https://fin-hypergrid.github.io/core/doc/module-defaults.html#.wheelHFactor).

### 9. Better dates in dev testbench data \[bug]
Better date range with no invalid dates as appeared in some browsers.

### 10. Fix jsdocs typo: `options.contextAttributes` \[docs]
Option was renamed (from `canvasContextAttributes`) before merge of [**v2.1.5**](https://github.com/fin-hypergrid/core/releases/tag/v2.1.15) but jsdoc comments unfortunately got out of sync, disappointing anyone trying the option using the erroneous name in the docs.

### 11. Reorganize and update the Tutorial
The tutorial has a new home (actually a symlink):

> http://fin-hypergrid.github.io/core/tutorial

Highlights:
* The instructions on how to use the tutorial itself, previously mixed in with the tutorial proper, have been teased out and move into new **Help** tabs.
* There is a new **Scrollbars** tab for help with styling and placing the Hypergrid scrollbars.

Note that the tutorial lives in [a separate repo](https://github.com/fin-hypergrid/build/tree/master/demo/formatter-workbench) but will be available on the same CDN as the build file.

### 12. Updated copyright notice
The copyright notice was updated from "© 2015 Openfin"  to "© 2015 Openfin and The Hypergrid Authors" in:
* `./LICENSE` file
* `jsdoc-template-hypergrid` submodule (which puts the copyright notice at the bottom of every doc page) (See [a separate PR](https://github.com/fin-hypergrid/jsdoc-template-hypergrid/pull/1) in another repo.)

### 13. Updated license
The following restriction has been _removed_ from the license:

> ~~You may not redistribute the software or modifications as part of any application that can be described as a development toolkit, library or framework.~~

This change makes the license back into a plain vanilla `MIT` license (per `./package.json`).