### PR TITLE
Add mouse event details

### DIFF
--- a/src/Hypergrid/events.js
+++ b/src/Hypergrid/events.js
@@ -458,6 +458,25 @@ exports.mixin = {
                         writable: true
                     }
                 );
+
+                // add some interesting mouse offsets
+                var drilldown;
+                if ((drilldown = primitiveEvent.primitiveEvent && primitiveEvent.primitiveEvent.detail)) {
+                    decoratedEvent.gridPoint = drilldown.mouse;
+                    if ((drilldown = drilldown.primitiveEvent)) {
+                        decoratedEvent.clientPoint = {
+                            x: drilldown.clientX,
+                            y: drilldown.clientY
+                        };
+                        decoratedEvent.pagePoint = {
+                            x: drilldown.clientX + window.scrollX,
+                            y: drilldown.clientY + window.scrollY
+                        };
+                    }
+                }
+
+
+
                 cb.call(grid, decoratedEvent);
             }
         }
@@ -576,7 +595,7 @@ exports.mixin = {
         });
 
         this.addInternalEventListener('fin-canvas-context-menu', function(e) {
-            handleMouseEvent(e, function(mouseEvent){
+            handleMouseEvent(e, function(mouseEvent) {
                 grid.delegateContextMenu(mouseEvent);
                 grid.fireSyntheticContextMenuEvent(mouseEvent);
             });

--- a/src/lib/dispatchGridEvent.js
+++ b/src/lib/dispatchGridEvent.js
@@ -6,6 +6,9 @@ var details = [
     'gridCell',
     'dataCell',
     'mousePoint',
+    'gridPoint',
+    'clientPoint',
+    'pagePoint',
     'keys',
     'row'
 ];


### PR DESCRIPTION
This PR intended for next release, v3.2.0.

The following details have been added to hypergrid mouse events:

Property | New? | Description
--- | :---: | ---
`event.detail.mousePoint.x`<br>`event.detail.mousePoint.y` | no | pixel offsets from top left corner of grid cell
`event.detail.offsetGrid.x`<br>`event.detail.offsetGrid.y` | yes | pixel offsets from top left corner of grid
`event.detail.offsetClient.x`<br>`event.detail.offsetClient.y` | yes | pixel offsets from top left corner of window (regardless of page scrolling)
`event.detail.offsetPage.x`<br>`event.detail.offsetPage.y` | yes | pixel offsets from top left corner of document (which may be scrolled up and/or left and out of view)

This data was already available, buried deep in the drilldowns. This PR just copies them up to the `event.detail` level for convenience, with more semantic naming.