### PR TITLE
Add Registry.prototype.make

### DIFF
--- a/src/lib/Registry.js
+++ b/src/lib/Registry.js
@@ -32,6 +32,7 @@ var Registry = Base.extend('Registry', {
             return;
         }
 
+        // getClassName defined if new item derived from extend-me
         name = name || item.getClassName && item.getClassName();
 
         if (!name) {
@@ -58,6 +59,16 @@ var Registry = Base.extend('Registry', {
      */
     addSynonym: function(synonymName, existingName) {
         return (this.items[synonymName] = this.items[existingName]);
+    },
+
+    /**
+     * Create a new item extended from base class. For formal parameters, see {@link Registry#add add}.
+     * @memberOf Registry#
+     */
+    make: function(name, prototype) {
+        var last = arguments.length - 1;
+        arguments[last] = this.BaseClass.extend(arguments[last]);
+        this.add.apply(this, arguments);
     },
 
     /**


### PR DESCRIPTION
This PR targets the next release, `v3.2.0`.
```js
Registry.prototype.make = function(name, prototype) // name is optional
```
This new convenience method creates a new class extended from the registry's base class (registry.BaseClass) and then adds it. The registry name is determined either by the first parameter if provided OR from a `name` property or `$$CLASS_NAME` property in the provided prototype.