### PR TITLE
Add Base.prototype.versionAtLeast

### DIFF
--- a/src/Base.js
+++ b/src/Base.js
@@ -19,14 +19,16 @@ Object.defineProperty(Base.prototype, 'version', {
     value: require('../package.json').version
 });
 
-Base.prototype.atLeastVersion = function(neededVersion) {
-    var neededParts = neededVersion.split('.'),
-        thisParts = this.version.split('.'),
-        delta;
-    neededParts.find(function(neededPart, i) {
-        return (delta = neededPart - thisParts[i]);
-    });
-    return delta >= 0;
+Base.prototype.versionAtLeast = function(neededVersion) {
+    var neededParts = neededVersion.split('.').map(Number),
+        delta = this.version.split('.').map(function(part, i) { return Number(part) - neededParts[i]; });
+    return (
+        delta[0] > 0 ||
+        delta[0] === 0 && (
+            delta[1] > 0 ||
+            delta[1] === 0 && delta[2] >= 0
+        )
+    );
 };
 
 Base.prototype.deprecated = require('./lib/deprecated');


### PR DESCRIPTION
This PR targets the next release, `v3.2.0`.
```js
Base.prototype.versionAtLeast = function(version /* string */) { ... return /*boolean*/ }
```

This new function compares the passed version string to the current version and returns `true` if the current version is newer. Caveat: Because it's new, it is only useful for arguments >= `3.2.0`.