### PR TITLE
Issue #784 Anonymous column calculator bug

### DIFF
--- a/src/behaviors/Column.js
+++ b/src/behaviors/Column.js
@@ -390,7 +390,7 @@ function resolveCalculator(calculator) {
         }
     } else if ((matches = calculator.match(REGEX_NAMED_FUNC))) {
         key = matches[1]; // function name extracted from stringified function
-    } else if (calculator.test(REGEX_ANON_FUNC)) {
+    } else if (REGEX_ANON_FUNC.test(calculator)) {
         key = calculator; // anonymous stringified function
     } else if (REGEX_ARROW_FUNC.test(calculator)) {
         throw new HypergridError('Arrow function not permitted as column calculator ' + forColumnName);

--- a/src/behaviors/Column.js
+++ b/src/behaviors/Column.js
@@ -383,15 +383,21 @@ function resolveCalculator(calculator) {
     var matches, key,
         calculators = this.behavior.grid.properties.calculators || (this.behavior.grid.properties.calculators = {});
 
-    if (/^\w+$/.test(calculator)) {
-        key = calculator; // just a function name
+    if (/^\w+$/.test(calculator)) { // just a function name?
+        // use as registry key but make sure it is in fact a registered calculator
+        key = calculator;
         if (!calculators[key]) {
             throw new HypergridError('Unknown calculator name "' + key + forColumnName);
         }
-    } else if ((matches = calculator.match(REGEX_NAMED_FUNC))) {
-        key = matches[1]; // function name extracted from stringified function
-    } else if (REGEX_ANON_FUNC.test(calculator)) {
-        key = calculator; // anonymous stringified function
+
+    } else if ((matches = calculator.match(REGEX_NAMED_FUNC))) { // named stringified function?
+        // extract function name from stringified function to use as registry key
+        key = matches[1];
+
+    } else if (REGEX_ANON_FUNC.test(calculator)) { // anonymous stringified function?
+        // use entire anonymous stringified function as registry key
+        key = calculator;
+
     } else if (REGEX_ARROW_FUNC.test(calculator)) {
         throw new HypergridError('Arrow function not permitted as column calculator ' + forColumnName);
     }


### PR DESCRIPTION
### Resolution

This PR (specifically 1727b44) fixes the bug reported in Issue #784.

This issue was with the `column.calculator` property overload where the value is a stringified anonymous function (use case 2 below).

### `calculator` setter overloads
The `calculator` property setter is overloaded for any of the following use cases:
1. Registered function name
   * Function is dereferenced from the calculators registry
2. _Anonymous_ stringified function
   * The string is functionified (inflated into an actual function object)
   * The function is registered (if not already in the registry) using the _entire function string_ as the registry key
   * Registering the function normalizes other references to it, _i.e.,_ other references to the identical function string will not be individually functionified but will use the function in the registry
3. _Named_ stringified function
   * The string is functionified
   * The function is registered (if not already in the registry) using the _function name_ as the registry key
   * Registering the function normalizes other references to it, _i.e.,_ referenced either with a function string using the same name (the first such function definition is the one that is registered) or simply by name (use case 1 above)
4. Actual function object
   * The function object is stringified and then treated as use case 2 or 3 above as the case may be.
   * Note that this process strips the function of its execution context, which would be lost anyway when state is persisted (serialized). _For a work-around if context is needed, see #785. If you use this work-around, you cannot persist your function with its context and you will need to programmatically recreate it whenever state is reloaded from persistent storage._