### PR TITLE
removed blitting support

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -816,16 +816,6 @@ var defaults = {
      */
     repaintImmediately: false,
 
-    //enable or disable double buffering
-
-    /**
-     * @default
-     * @type {boolean}
-     * @memberOf module:defaults
-     */
-    useBitBlit: false,
-
-
     /**
      * @default
      * @type {boolean}


### PR DESCRIPTION
This dubious feature which was off by default did not contribute anything to performance (on Chrome at least) and complicated the code.

Removed `grid.properties.useBitBlit`, `grid.canvas.bc`, `grid.canvas.buffer`; the `grid.canvas.flushBuffer()` method is now a no-op.

Not sure why the original author thought this would help. Normally used to composite smaller bitmpas into a larger bitmap so those portions don't have to redraw the entire view on every frame. This is not the case with Hypergrid where we are redrawing the entire grid on every frame. The other concept of prepping an off-stage view while the user is looking at the current frame is not an advantage if the entire frame can be drawn during blanking. There is no parallel processing in JS especially when GPU is bottleneck. Maybe I don't get it; maybe we can make this work for us. If so we can always put it back in.