### PR TITLE
Respect style.zoom

### DIFF
--- a/src/Hypergrid/index.js
+++ b/src/Hypergrid/index.js
@@ -1482,19 +1482,8 @@ var Hypergrid = Base.extend('Hypergrid', {
      * @memberOf Hypergrid#
      * @returns {number} The HiDPI ratio.
      */
-    getHiDPI: function(ctx) {
-        if (window.devicePixelRatio && this.properties.useHiDPI) {
-            var devicePixelRatio = window.devicePixelRatio || 1,
-                backingStoreRatio = ctx.webkitBackingStorePixelRatio ||
-                    ctx.mozBackingStorePixelRatio ||
-                    ctx.msBackingStorePixelRatio ||
-                    ctx.oBackingStorePixelRatio ||
-                    ctx.backingStorePixelRatio || 1,
-                result = devicePixelRatio / backingStoreRatio;
-        } else {
-            result = 1;
-        }
-        return result;
+    getHiDPI: function() {
+        return this.canvas.devicePixelRatio;
     },
 
     /**
@@ -1568,6 +1557,35 @@ var Hypergrid = Base.extend('Hypergrid', {
         var column = columnOrIndex >= -2 ? this.behavior.getActiveColumn(columnOrIndex) : columnOrIndex;
         column.checkColumnAutosizing(true);
         this.computeCellsBounds();
+    },
+
+    /**
+     /**
+     * @memberOf Hypergrid#
+     * @desc Reset zoom factor used by mouse tracking and placement
+     * of cell editors on top of canvas.
+     *
+     * Call this after externally resetting the `zoom` CSS style
+     * of any of the elements `<body>`..`<canvas>` (inclusive).
+     *
+     * **NOTE THE FOLLOWING:**
+     * 1. `zoom` is non-standard (unsupported by FireFox)
+     * 2. The alternative suggested on MDN, `transform`, is ignored
+     * here as it is not a practical replacement for `zoom`.
+     * @see https://developer.mozilla.org/en-US/docs/Web/CSS/zoom
+     *
+     * **RECOMMENDATION:** If possible keep things simple and use
+     * `body.style.zoom` only (especially considering scroll bar issue).
+     *
+     * @todo Scrollbars need to be repositioned when `canvas.style.zoom` !== 1. (May need update to finbars.)
+     */
+    resetZoom: function() {
+        this.canvas.resetZoom();
+        this.abortEditing();
+    },
+
+    getZoomFactor: function() {
+        return this.canvas.zoomFactor;
     },
 
     /**

--- a/src/cellEditors/CellEditor.js
+++ b/src/cellEditors/CellEditor.js
@@ -437,11 +437,12 @@ var CellEditor = Base.extend('CellEditor', {
      */
     setBounds: function(cellBounds) {
         var style = this.el.style;
+        var zoomFactor = this.grid.getZoomFactor();
 
-        style.left = px(cellBounds.x);
-        style.top = px(cellBounds.y);
-        style.width = px(cellBounds.width);
-        style.height = px(cellBounds.height);
+        style.left   = px(zoomFactor * cellBounds.x);
+        style.top    = px(zoomFactor * cellBounds.y);
+        style.width  = px(zoomFactor * cellBounds.width);
+        style.height = px(zoomFactor * cellBounds.height);
     },
 
     /**

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -816,16 +816,6 @@ var defaults = {
      */
     repaintImmediately: false,
 
-    //enable or disable double buffering
-
-    /**
-     * @default
-     * @type {boolean}
-     * @memberOf module:defaults
-     */
-    useBitBlit: false,
-
-
     /**
      * @default
      * @type {boolean}

--- a/src/features/ColumnMoving.js
+++ b/src/features/ColumnMoving.js
@@ -18,6 +18,13 @@ var draggerCTX;
 var floatColumn;
 var floatColumnCTX;
 
+function translate(grid, x, y) {
+    var zoomFactor = grid.getZoomFactor();
+    x *= zoomFactor;
+    y *= zoomFactor;
+    return 'translate(' + x + 'px, ' + y + 'px)';
+}
+
 /**
  * @constructor
  * @extends Feature
@@ -297,14 +304,14 @@ var ColumnMoving = Feature.extend('ColumnMoving', {
         return function() {
             var d = floatColumn;
             d.style.display = 'inline';
-            self.setCrossBrowserProperty(d, 'transform', 'translate(' + floaterStartX + 'px, ' + 0 + 'px)');
+            self.setCrossBrowserProperty(d, 'transform', translate(grid, floaterStartX, 0));
 
             //d.style.webkit-webkit-Transform = 'translate(' + floaterStartX + 'px, ' + 0 + 'px)';
             //d.style.webkit-webkit-Transform = 'translate(' + floaterStartX + 'px, ' + 0 + 'px)';
 
             requestAnimationFrame(function() {
                 self.setCrossBrowserProperty(d, 'transition', (self.isWebkit ? '-webkit-' : '') + 'transform ' + columnAnimationTime + 'ms ease');
-                self.setCrossBrowserProperty(d, 'transform', 'translate(' + draggerStartX + 'px, ' + -2 + 'px)');
+                self.setCrossBrowserProperty(d, 'transform', translate(grid, draggerStartX, -2));
             });
             grid.repaint();
             //need to change this to key frames
@@ -353,7 +360,7 @@ var ColumnMoving = Feature.extend('ColumnMoving', {
         }
 
         var columnWidth = grid.getColumnWidth(columnIndex);
-        var colHeight = grid.div.clientHeight;
+        var colHeight = grid.canvas.canvas.clientHeight;
         var d = floatColumn;
         var style = d.style;
         var location = grid.div.getBoundingClientRect();
@@ -361,13 +368,13 @@ var ColumnMoving = Feature.extend('ColumnMoving', {
         style.top = (location.top - 2) + 'px';
         style.left = location.left + 'px';
 
-        var hdpiRatio = grid.getHiDPI(floatColumnCTX);
+        var hdpiRatio = grid.getHiDPI();
 
-        d.setAttribute('width', Math.round(columnWidth * hdpiRatio) + 'px');
-        d.setAttribute('height', Math.round(colHeight * hdpiRatio) + 'px');
+        d.setAttribute('width', Math.round(columnWidth * hdpiRatio));
+        d.setAttribute('height', Math.round(colHeight * hdpiRatio));
         style.boxShadow = '0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23)';
-        style.width = columnWidth + 'px'; //Math.round(columnWidth / hdpiRatio) + 'px';
-        style.height = colHeight + 'px'; //Math.round(colHeight / hdpiRatio) + 'px';
+        style.width = columnWidth * grid.getZoomFactor() + 'px'; //Math.round(columnWidth / hdpiRatio) + 'px';
+        style.height = colHeight * grid.getZoomFactor() + 'px'; //Math.round(colHeight / hdpiRatio) + 'px';
         style.borderTop = '1px solid ' + grid.properties.lineColor;
         style.backgroundColor = grid.properties.backgroundColor;
 
@@ -385,7 +392,7 @@ var ColumnMoving = Feature.extend('ColumnMoving', {
         };
 
         style.zIndex = '4';
-        this.setCrossBrowserProperty(d, 'transform', 'translate(' + startX + 'px, ' + -2 + 'px)');
+        this.setCrossBrowserProperty(d, 'transform', translate(grid, startX, -2));
         GRABBING.forEach(setName, style);
         grid.repaint();
     },
@@ -435,9 +442,9 @@ var ColumnMoving = Feature.extend('ColumnMoving', {
             scrollLeft = 0;
         }
 
-        var hdpiRatio = grid.getHiDPI(draggerCTX);
+        var hdpiRatio = grid.getHiDPI();
         var columnWidth = grid.getColumnWidth(columnIndex);
-        var colHeight = grid.div.clientHeight;
+        var colHeight = grid.canvas.canvas.clientHeight;
         var d = dragger;
         var location = grid.div.getBoundingClientRect();
         var style = d.style;
@@ -450,11 +457,11 @@ var ColumnMoving = Feature.extend('ColumnMoving', {
         style.borderTop = '1px solid ' + grid.properties.lineColor;
         style.backgroundColor = grid.properties.backgroundColor;
 
-        d.setAttribute('width', Math.round(columnWidth * hdpiRatio) + 'px');
-        d.setAttribute('height', Math.round(colHeight * hdpiRatio) + 'px');
+        d.setAttribute('width', Math.round(columnWidth * hdpiRatio));
+        d.setAttribute('height', Math.round(colHeight * hdpiRatio));
 
-        style.width = columnWidth + 'px'; //Math.round(columnWidth / hdpiRatio) + 'px';
-        style.height = colHeight + 'px'; //Math.round(colHeight / hdpiRatio) + 'px';
+        style.width = columnWidth * grid.getZoomFactor() + 'px'; //Math.round(columnWidth / hdpiRatio) + 'px';
+        style.height = colHeight * grid.getZoomFactor() + 'px'; //Math.round(colHeight / hdpiRatio) + 'px';
 
         var startX = grid.renderer.visibleColumns[columnIndex - scrollLeft].left * hdpiRatio;
 
@@ -470,7 +477,7 @@ var ColumnMoving = Feature.extend('ColumnMoving', {
             hdpiratio: hdpiRatio
         };
 
-        this.setCrossBrowserProperty(d, 'transform', 'translate(' + x + 'px, -5px)');
+        this.setCrossBrowserProperty(d, 'transform', translate(grid, x, -5));
         style.zIndex = '5';
         GRABBING.forEach(setName, style);
         grid.repaint();
@@ -489,7 +496,7 @@ var ColumnMoving = Feature.extend('ColumnMoving', {
 
         var autoScrollingNow = this.columnDragAutoScrollingRight || this.columnDragAutoScrollingLeft;
 
-        var hdpiRatio = grid.getHiDPI(draggerCTX);
+        var hdpiRatio = grid.getHiDPI();
 
         var dragColumnIndex = grid.renderOverridesCache.dragger.columnIndex;
 
@@ -508,7 +515,7 @@ var ColumnMoving = Feature.extend('ColumnMoving', {
 
         this.setCrossBrowserProperty(d, 'transition', (self.isWebkit ? '-webkit-' : '') + 'transform ' + 0 + 'ms ease, box-shadow ' + columnAnimationTime + 'ms ease');
 
-        this.setCrossBrowserProperty(d, 'transform', 'translate(' + x + 'px, ' + -10 + 'px)');
+        this.setCrossBrowserProperty(d, 'transform', translate(grid, x, -10));
         requestAnimationFrame(function() {
             d.style.display = 'inline';
         });
@@ -639,7 +646,7 @@ var ColumnMoving = Feature.extend('ColumnMoving', {
         var d = dragger;
         var changed = grid.renderOverridesCache.dragger.startIndex !== grid.renderOverridesCache.dragger.columnIndex;
         self.setCrossBrowserProperty(d, 'transition', (self.isWebkit ? '-webkit-' : '') + 'transform ' + columnAnimationTime + 'ms ease, box-shadow ' + columnAnimationTime + 'ms ease');
-        self.setCrossBrowserProperty(d, 'transform', 'translate(' + startX + 'px, ' + -1 + 'px)');
+        self.setCrossBrowserProperty(d, 'transform', translate(grid, startX, -1));
         d.style.boxShadow = '0px 0px 0px #888888';
 
         setTimeout(function() {

--- a/src/lib/Canvas.js
+++ b/src/lib/Canvas.js
@@ -22,6 +22,10 @@ var RESIZE_POLLING_INTERVAL = 200,
     resizeInterval,
     charMap = makeCharMap();
 
+// We still support IE 11; we do NOT support older versions of IE (and we do NOT officially support Edge)
+// https://stackoverflow.com/questions/21825157/internet-explorer-11-detection#answer-21825207
+var isIE11 = !!(window.MSInputMethodContext && document.documentMode);
+
 function Canvas(div, component, contextAttributes) {
     var self = this;
 
@@ -108,6 +112,8 @@ function Canvas(div, component, contextAttributes) {
     });
 
     this.canvas.setAttribute('tabindex', 0);
+
+    this.resetZoom();
 
     this.resize();
 
@@ -225,9 +231,34 @@ Canvas.prototype = {
         this.stopResizing();
     },
 
+    getBoundingClientRect: function(el) {
+        var rect = el.getBoundingClientRect();
+
+        if (isIE11) {
+            var r = 1 / this.zoomFactor;
+            var top = rect.top * r;
+            var right = rect.right * r;
+            var bottom = rect.bottom * r;
+            var left = rect.left * r;
+
+            rect = {
+                top: top,
+                right: right,
+                bottom: bottom,
+                left: left,
+                width: right - left,
+                height: bottom - top,
+                x: left,
+                y: top
+            };
+        }
+
+        return rect;
+    },
+
     getDivBoundingClientRect: function() {
         // Make sure our canvas has integral dimensions
-        var rect = this.div.getBoundingClientRect();
+        var rect = this.getBoundingClientRect(this.div);
         var top = Math.floor(rect.top),
             left = Math.floor(rect.left),
             width = Math.ceil(rect.width),
@@ -246,15 +277,14 @@ Canvas.prototype = {
     },
 
     checksize: function() {
-        //this is expensive lets do it at some modulo
         var sizeNow = this.getDivBoundingClientRect();
         if (sizeNow.width !== this.size.width || sizeNow.height !== this.size.height) {
-            this.resize();
+            this.resize(sizeNow);
         }
     },
 
-    resize: function() {
-        var box = this.size = this.getDivBoundingClientRect();
+    resize: function(box) {
+        box = this.size = box || this.getDivBoundingClientRect();
 
         this.width = box.width;
         this.height = box.height;
@@ -263,8 +293,10 @@ Canvas.prototype = {
         var isHIDPI = window.devicePixelRatio && this.component.properties.useHiDPI;
         var ratio = isHIDPI && window.devicePixelRatio || 1;
 
-        this.canvas.width = this.width * ratio;
-        this.canvas.height = this.height * ratio;
+        this.devicePixelRatio = ratio *= this.zoomFactor;
+
+        this.canvas.width = Math.round(this.width * ratio);
+        this.canvas.height = Math.round(this.height * ratio);
 
         this.canvas.style.width = this.width + 'px';
         this.canvas.style.height = this.height + 'px';
@@ -282,6 +314,43 @@ Canvas.prototype = {
             width: this.width,
             height: this.height
         });
+    },
+
+    resetZoom: function() {
+        var factor = 1;
+        var el = this.canvas;
+        var htmlEl = document.body.parentElement;
+
+        // html.style.zoom is the browser zoom (from ctrl +/-) which is
+        // excluded from this factor calculation because it does not
+        // affect coordinate calculations. It is however naturally
+        // included in resize() logic as it is a factor in devicePixelRatio.
+
+        while (el !== htmlEl) {
+            // IE11 bug: must use getPropertyValue because zoom is omitted from returned object
+            var zoomProp = getComputedStyle(el).getPropertyValue('zoom');
+            var zoom;
+
+            if (zoomProp) {
+                // IE11: always returns percentage + percent sign
+                var m = zoomProp.match(/^(.+?)(%)?$/);
+                if (m) {
+                    zoom = Number(m[1]);
+                    if (m[2]) {
+                        zoom /= 100;
+                    }
+                }
+            }
+
+            zoom = Number(zoom || 1);
+            factor *= zoom;
+
+            el = el.parentElement;
+        }
+
+        this.zoomFactor = factor;
+
+        this.resize();
     },
 
     getBounds: function() {
@@ -345,7 +414,6 @@ Canvas.prototype = {
             this.dragstart = new rectangular.Point(this.mouseLocation.x, this.mouseLocation.y);
         }
         this.mouseLocation = this.getLocal(e);
-        //console.log(this.mouseLocation);
         if (this.isDragging()) {
             this.dispatchNewMouseKeysEvent(e, 'fin-canvas-drag', {
                 dragstart: this.dragstart,
@@ -553,14 +621,19 @@ Canvas.prototype = {
     },
 
     getOrigin: function() {
-        var rect = this.canvas.getBoundingClientRect();
+        var rect = this.getBoundingClientRect(this.canvas);
         var p = new rectangular.Point(rect.left, rect.top);
         return p;
     },
 
     getLocal: function(e) {
-        var rect = this.canvas.getBoundingClientRect();
-        var p = new rectangular.Point(e.clientX - rect.left, e.clientY - rect.top);
+        var rect = this.getBoundingClientRect(this.canvas);
+
+        var p = new rectangular.Point(
+            e.clientX / this.zoomFactor - rect.left,
+            e.clientY / this.zoomFactor - rect.top
+        );
+
         return p;
     },
 


### PR DESCRIPTION
HTMLElement..style.zoom is non-standard but widely supported. (The only exception is Firefox.)

This PR adds the following support for when a Hypergrid is zoomed by this feature (when any elements from `<body>` to `<canvas>` have their `zoom` style set to something other than `1`):

1. Canvas resolution is now optimized with respect to the zoom settings of all the elements in the chain
2. Mouse tracking coordinates are now properly adjusted when zoomed

Tested on Chrome, Safari, IE 11 (which needed some special case coding), and regression tested on Firefox where it has no effect.

Added method `grid.resetZoom()` which should be called:
1.  **Any time you set the `zoom` style of one or more of the elements in the chain.** This does two things: Optimizes the canvas resolution; adjusts the mouse coordinates.
2.  **After user adjusts browser zoom using ctrl +/- to optimize the resolution.** This optimizes the canvas resolution for a sharper image. The mouse coordinates are not adjusted for browser zoom. The only way to tell if browser zoom changed (I believe) is to poll `getComputedStyle(htmlElement).zoom` (where `htmlElement = document.body.parentElement`).

