### PR TITLE
respect document.body.style.zoom

### DIFF
--- a/src/Hypergrid/index.js
+++ b/src/Hypergrid/index.js
@@ -239,6 +239,15 @@ var Hypergrid = Base.extend('Hypergrid', {
     isWebkit: true,
 
     /**
+     * We still support IE 11; we do NOT support older versions of IE.
+     * (We do NOT officially support Edge.)
+     * @see https://stackoverflow.com/questions/21825157/internet-explorer-11-detection#answer-21825207
+     * @type {boolean}
+     * @memberOf Hypergrid#
+     */
+    isIE11: !!(window.MSInputMethodContext && document.documentMode),
+
+    /**
      * The pixel location of an initial mousedown click, either for editing a cell or for dragging a selection.
      * @type {Point}
      * @memberOf Hypergrid#
@@ -1482,19 +1491,8 @@ var Hypergrid = Base.extend('Hypergrid', {
      * @memberOf Hypergrid#
      * @returns {number} The HiDPI ratio.
      */
-    getHiDPI: function(ctx) {
-        if (window.devicePixelRatio && this.properties.useHiDPI) {
-            var devicePixelRatio = window.devicePixelRatio || 1,
-                backingStoreRatio = ctx.webkitBackingStorePixelRatio ||
-                    ctx.mozBackingStorePixelRatio ||
-                    ctx.msBackingStorePixelRatio ||
-                    ctx.oBackingStorePixelRatio ||
-                    ctx.backingStorePixelRatio || 1,
-                result = devicePixelRatio / backingStoreRatio;
-        } else {
-            result = 1;
-        }
-        return result;
+    getHiDPI: function() {
+        return this.canvas.devicePixelRatio;
     },
 
     /**
@@ -1568,6 +1566,31 @@ var Hypergrid = Base.extend('Hypergrid', {
         var column = columnOrIndex >= -2 ? this.behavior.getActiveColumn(columnOrIndex) : columnOrIndex;
         column.checkColumnAutosizing(true);
         this.computeCellsBounds();
+    },
+
+    /**
+     * @memberOf Hypergrid#
+     * @desc Reset zoom factor used by mouse tracking and placement
+     * of cell editors on top of canvas.
+     *
+     * Call this after resetting `document.body.style.zoom`.
+     * (Do not set `zoom` style on canvas or any other ancestor thereof.)
+     *
+     * **NOTE THE FOLLOWING:**
+     * 1. `zoom` is non-standard (unsupported by FireFox)
+     * 2. The alternative suggested on MDN, `transform`, is ignored
+     * here as it is not a practical replacement for `zoom`.
+     * @see https://developer.mozilla.org/en-US/docs/Web/CSS/zoom
+     *
+     * @todo Scrollbars need to be repositioned when `canvas.style.zoom` !== 1. (May need update to finbars.)
+     */
+    resetZoom: function() {
+        this.abortEditing();
+        this.canvas.resetZoom();
+    },
+
+    getBodyZoomFactor: function() {
+        return this.canvas.bodyZoomFactor;
     },
 
     /**

--- a/src/features/ColumnMoving.js
+++ b/src/features/ColumnMoving.js
@@ -18,6 +18,15 @@ var draggerCTX;
 var floatColumn;
 var floatColumnCTX;
 
+function translate(grid, x, y) {
+    if (grid.isIE11) {
+        var zoomFactor = grid.getBodyZoomFactor();
+        x *= zoomFactor;
+        y *= zoomFactor;
+    }
+    return 'translate(' + x + 'px, ' + y + 'px)';
+}
+
 /**
  * @constructor
  * @extends Feature
@@ -297,14 +306,14 @@ var ColumnMoving = Feature.extend('ColumnMoving', {
         return function() {
             var d = floatColumn;
             d.style.display = 'inline';
-            self.setCrossBrowserProperty(d, 'transform', 'translate(' + floaterStartX + 'px, ' + 0 + 'px)');
+            self.setCrossBrowserProperty(d, 'transform', translate(grid, floaterStartX, 0));
 
             //d.style.webkit-webkit-Transform = 'translate(' + floaterStartX + 'px, ' + 0 + 'px)';
             //d.style.webkit-webkit-Transform = 'translate(' + floaterStartX + 'px, ' + 0 + 'px)';
 
             requestAnimationFrame(function() {
                 self.setCrossBrowserProperty(d, 'transition', (self.isWebkit ? '-webkit-' : '') + 'transform ' + columnAnimationTime + 'ms ease');
-                self.setCrossBrowserProperty(d, 'transform', 'translate(' + draggerStartX + 'px, ' + -2 + 'px)');
+                self.setCrossBrowserProperty(d, 'transform', translate(grid, draggerStartX, -2));
             });
             grid.repaint();
             //need to change this to key frames
@@ -353,7 +362,7 @@ var ColumnMoving = Feature.extend('ColumnMoving', {
         }
 
         var columnWidth = grid.getColumnWidth(columnIndex);
-        var colHeight = grid.div.clientHeight;
+        var colHeight = grid.canvas.canvas.clientHeight;
         var d = floatColumn;
         var style = d.style;
         var location = grid.div.getBoundingClientRect();
@@ -361,13 +370,16 @@ var ColumnMoving = Feature.extend('ColumnMoving', {
         style.top = (location.top - 2) + 'px';
         style.left = location.left + 'px';
 
-        var hdpiRatio = grid.getHiDPI(floatColumnCTX);
+        var hdpiRatio = grid.getHiDPI();
 
-        d.setAttribute('width', Math.round(columnWidth * hdpiRatio) + 'px');
-        d.setAttribute('height', Math.round(colHeight * hdpiRatio) + 'px');
+        d.setAttribute('width', Math.round(columnWidth * hdpiRatio));
+        d.setAttribute('height', Math.round(colHeight * hdpiRatio));
         style.boxShadow = '0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23)';
-        style.width = columnWidth + 'px'; //Math.round(columnWidth / hdpiRatio) + 'px';
-        style.height = colHeight + 'px'; //Math.round(colHeight / hdpiRatio) + 'px';
+
+        var zoomFactor = grid.isIE11 ? grid.getBodyZoomFactor() : 1;
+        style.width = columnWidth * zoomFactor + 'px'; //Math.round(columnWidth / hdpiRatio) + 'px';
+        style.height = colHeight * zoomFactor + 'px'; //Math.round(colHeight / hdpiRatio) + 'px';
+
         style.borderTop = '1px solid ' + grid.properties.lineColor;
         style.backgroundColor = grid.properties.backgroundColor;
 
@@ -385,7 +397,7 @@ var ColumnMoving = Feature.extend('ColumnMoving', {
         };
 
         style.zIndex = '4';
-        this.setCrossBrowserProperty(d, 'transform', 'translate(' + startX + 'px, ' + -2 + 'px)');
+        this.setCrossBrowserProperty(d, 'transform', translate(grid, startX, -2));
         GRABBING.forEach(setName, style);
         grid.repaint();
     },
@@ -435,9 +447,9 @@ var ColumnMoving = Feature.extend('ColumnMoving', {
             scrollLeft = 0;
         }
 
-        var hdpiRatio = grid.getHiDPI(draggerCTX);
+        var hdpiRatio = grid.getHiDPI();
         var columnWidth = grid.getColumnWidth(columnIndex);
-        var colHeight = grid.div.clientHeight;
+        var colHeight = grid.canvas.canvas.clientHeight;
         var d = dragger;
         var location = grid.div.getBoundingClientRect();
         var style = d.style;
@@ -450,11 +462,12 @@ var ColumnMoving = Feature.extend('ColumnMoving', {
         style.borderTop = '1px solid ' + grid.properties.lineColor;
         style.backgroundColor = grid.properties.backgroundColor;
 
-        d.setAttribute('width', Math.round(columnWidth * hdpiRatio) + 'px');
-        d.setAttribute('height', Math.round(colHeight * hdpiRatio) + 'px');
+        d.setAttribute('width', Math.round(columnWidth * hdpiRatio));
+        d.setAttribute('height', Math.round(colHeight * hdpiRatio));
 
-        style.width = columnWidth + 'px'; //Math.round(columnWidth / hdpiRatio) + 'px';
-        style.height = colHeight + 'px'; //Math.round(colHeight / hdpiRatio) + 'px';
+        var zoomFactor = grid.isIE11 ? grid.getBodyZoomFactor() : 1;
+        style.width = columnWidth * zoomFactor + 'px'; //Math.round(columnWidth / hdpiRatio) + 'px';
+        style.height = colHeight * zoomFactor + 'px'; //Math.round(colHeight / hdpiRatio) + 'px';
 
         var startX = grid.renderer.visibleColumns[columnIndex - scrollLeft].left * hdpiRatio;
 
@@ -470,7 +483,7 @@ var ColumnMoving = Feature.extend('ColumnMoving', {
             hdpiratio: hdpiRatio
         };
 
-        this.setCrossBrowserProperty(d, 'transform', 'translate(' + x + 'px, -5px)');
+        this.setCrossBrowserProperty(d, 'transform', translate(grid, x, -5));
         style.zIndex = '5';
         GRABBING.forEach(setName, style);
         grid.repaint();
@@ -489,7 +502,7 @@ var ColumnMoving = Feature.extend('ColumnMoving', {
 
         var autoScrollingNow = this.columnDragAutoScrollingRight || this.columnDragAutoScrollingLeft;
 
-        var hdpiRatio = grid.getHiDPI(draggerCTX);
+        var hdpiRatio = grid.getHiDPI();
 
         var dragColumnIndex = grid.renderOverridesCache.dragger.columnIndex;
 
@@ -508,7 +521,7 @@ var ColumnMoving = Feature.extend('ColumnMoving', {
 
         this.setCrossBrowserProperty(d, 'transition', (self.isWebkit ? '-webkit-' : '') + 'transform ' + 0 + 'ms ease, box-shadow ' + columnAnimationTime + 'ms ease');
 
-        this.setCrossBrowserProperty(d, 'transform', 'translate(' + x + 'px, ' + -10 + 'px)');
+        this.setCrossBrowserProperty(d, 'transform', translate(grid, x, -10));
         requestAnimationFrame(function() {
             d.style.display = 'inline';
         });
@@ -639,7 +652,7 @@ var ColumnMoving = Feature.extend('ColumnMoving', {
         var d = dragger;
         var changed = grid.renderOverridesCache.dragger.startIndex !== grid.renderOverridesCache.dragger.columnIndex;
         self.setCrossBrowserProperty(d, 'transition', (self.isWebkit ? '-webkit-' : '') + 'transform ' + columnAnimationTime + 'ms ease, box-shadow ' + columnAnimationTime + 'ms ease');
-        self.setCrossBrowserProperty(d, 'transform', 'translate(' + startX + 'px, ' + -1 + 'px)');
+        self.setCrossBrowserProperty(d, 'transform', translate(grid, startX, -1));
         d.style.boxShadow = '0px 0px 0px #888888';
 
         setTimeout(function() {


### PR DESCRIPTION
[`style.zoom`](https://developer.mozilla.org/en-US/docs/Web/CSS/zoom) is non-standard but widely supported. (The only exception is Firefox.)

This PR adds the following support for when a Hypergrid is zoomed by setting `document.body.style.zoom`:

1. Canvas resolution is now optimized with respect to the zoom settings of all the elements in the chain
2. Mouse tracking coordinates are now properly adjusted when zoomed

Tested on Chrome, Safari, IE 11, and regression tested on Firefox where it has no effect.

Added method `grid.resetZoom()` which should be called:
1.  **Any time you set the `document.body.style.zoom`.** This does two things: Optimizes the canvas resolution; adjusts the mouse coordinates.
2.  **After user adjusts browser zoom using ctrl +/- to optimize the resolution.** This optimizes the canvas resolution for a sharper image. The mouse coordinates are not adjusted for browser zoom. The only way to tell if browser zoom changed (I believe) is to poll `getComputedStyle(htmlElement).zoom` (where `htmlElement = document.body.parentElement`).

> Important caveat: Setting `zoom` style on any other element between `body` and `canvas` is _not_ accommodated by `resetZoom`.

